### PR TITLE
Use port_util front panel regex instead of Ethernet

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -268,7 +268,7 @@ def init_sync_d_interface_tables(db_conn):
     if_name_map_util, if_id_map_util = port_util.get_interface_oid_map(db_conn, blocking=False)
     for if_name, sai_id in if_name_map_util.items():
         if_name_str = if_name
-        if (re.match(port_util.SONIC_ETHERNET_RE_PATTERN, if_name_str) or \
+        if (re.match(port_util.SONIC_FRONT_PANEL_RE_PATTERN, if_name_str) or \
                 re.match(port_util.SONIC_ETHERNET_BP_RE_PATTERN, if_name_str) or \
                 re.match(port_util.SONIC_ETHERNET_IB_RE_PATTERN, if_name_str)):
             if_name_map[if_name] = sai_id
@@ -277,7 +277,7 @@ def init_sync_d_interface_tables(db_conn):
     # string or in sai id.
     # sai_id_key = namespace : sai_id
     for sai_id, if_name in if_id_map_util.items():
-        if (re.match(port_util.SONIC_ETHERNET_RE_PATTERN, if_name) or \
+        if (re.match(port_util.SONIC_FRONT_PANEL_RE_PATTERN, if_name) or \
                 re.match(port_util.SONIC_ETHERNET_BP_RE_PATTERN, if_name) or \
                 re.match(port_util.SONIC_ETHERNET_IB_RE_PATTERN, if_name)):
             if_id_map[get_sai_id_key(db_conn.namespace, sai_id)] = if_name
@@ -298,7 +298,7 @@ def init_sync_d_interface_tables(db_conn):
     elif len(if_id_map) < len(if_name_map) or len(oid_name_map) < len(if_name_map):
         # a length mismatch indicates a bad interface name
         logger.warning("SyncD database contains incoherent interface names. Interfaces must match pattern '{}'"
-                       .format(port_util.SONIC_ETHERNET_RE_PATTERN))
+                       .format(port_util.SONIC_FRONT_PANEL_RE_PATTERN))
         logger.warning("Port name map:\n" + pprint.pformat(if_name_map, indent=2))
 
 


### PR DESCRIPTION
What I did
Removed the dependency on the "Ethernet" string in the SONiC code base and added support
for extending the front panel port name pattern.

How I did it

Introduced FRONT_PANEL_PORT_PREFIX_REGEX that extends the old FRONT_PANEL_PORT_PREFIX ("Ethernet")
Updated all the relevant usage of the "Ethernet" throughout the code base to use the new regex pattern
How to verify it
Pass all UT and CI testing.

Why I did it
In order to support distinguishing between different types of front panel ports in a maintainable fashion.
Specifically, we are planning to bring up a system with 'service' ports (in addition to the regular ethernet data ports) - these
are lower speed ports that used for connection to accelerators, internal loopbacks and more.

**- Related Commits and Merge Strategy**
_This is part of a group of related commits and should be merged **after https://github.com/Azure/sonic-swss-common/pull/598 and https://github.com/Azure/sonic-buildimage/pull/10471 and https://github.com/Azure/sonic-py-swsssdk/pull/121**._

The full merge order is:

1. swss-common - https://github.com/Azure/sonic-swss-common/pull/598
2. sonic-buildimage - https://github.com/Azure/sonic-buildimage/pull/10471
3. swsssdk - https://github.com/Azure/sonic-py-swsssdk/pull/121
4. all the rest
     [ https://github.com/Azure/sonic-utilities/pull/2127](https://github.com/Azure/sonic-utilities/pull/2127)
     [ https://github.com/Azure/sonic-snmpagent/pull/251](https://github.com/Azure/sonic-snmpagent/pull/251)
     [ https://github.com/Azure/sonic-swss/pull/2223](https://github.com/Azure/sonic-swss/pull/2223)
     [ https://github.com/Azure/sonic-platform-daemons/pull/252](https://github.com/Azure/sonic-platform-daemons/pull/252)
     [ https://github.com/Azure/sonic-platform-common/pull/274](https://github.com/Azure/sonic-platform-common/pull/274)
