### PR TITLE
Support interface speed for PortChannels

### DIFF
--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -640,6 +640,9 @@
     "nexthop": "",
     "ifname": "lo"
   },
+  "LAG_MEMBER_TABLE:PortChannel01:Ethernet108": {
+    "status": "enabled"
+  },
   "LAG_MEMBER_TABLE:PortChannel01:Ethernet112": {
     "status": "enabled"
   },

--- a/tests/test_hc_interfaces.py
+++ b/tests/test_hc_interfaces.py
@@ -147,6 +147,25 @@ class TestGetNextPDU(TestCase):
         self.assertEqual(str(value0.name), str(ObjectIdentifier(12, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 15, 121))))
         self.assertEqual(value0.data, 40000)
 
+    def test_portchannel_speed(self):
+        """
+        For a portchannel, the speed should be the sum of all members' speeds
+        """
+        oid = ObjectIdentifier(12, 0, 0, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 15, 1000))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        print(response)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.GAUGE_32)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(12, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 15, 1001))))
+        self.assertEqual(value0.data, 200000)
+
     def test_no_description(self):
         """
         For a port with no speed in the db the result should be 40000


### PR DESCRIPTION
**- What I did**
This change makes SNMP report the correct interface speed for PortChannels instead of defaulting to 40G.

**- How I did it**
Similar to `intfutil`, the code simply sums up the interface speeds of all member ports. The logic for iterating over members is based on `_get_counter`.

**- How to verify it**
- Check `snmpwalk -v 2c -c public <IP> ifHighSpeed`, note that PortChannels are reported as 40G
- Apply the change
- Check again, note that the same speed as in `show interface status` is reported now.

**- Description for the changelog**
Support reporting interface speeds for PortChannels through SNMP