### PR TITLE
Remove LOGLEVEL DB since is no longer used

### DIFF
--- a/tests/mock_tables/asic0/database_config.json
+++ b/tests/mock_tables/asic0/database_config.json
@@ -22,11 +22,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/tests/mock_tables/asic1/database_config.json
+++ b/tests/mock_tables/asic1/database_config.json
@@ -22,11 +22,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/tests/mock_tables/asic2/database_config.json
+++ b/tests/mock_tables/asic2/database_config.json
@@ -22,11 +22,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/tests/mock_tables/database_config.json
+++ b/tests/mock_tables/database_config.json
@@ -22,11 +22,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",

--- a/tests/mock_tables/global_db/database_config.json
+++ b/tests/mock_tables/global_db/database_config.json
@@ -22,11 +22,6 @@
             "separator": ":",
             "instance" : "redis"
         },
-        "LOGLEVEL_DB" : {
-            "id" : 3,
-            "separator": ":",
-            "instance" : "redis"
-        },
         "CONFIG_DB" : {
             "id" : 4,
             "separator": "|",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
This PR is part of the following HLD:
Persistent loglevel HLD: https://github.com/sonic-net/SONiC/pull/1041

**- What I did**
Deleted the LOGLEVEL_DB.
After the Logger tables moved from the LOGLEVEL_DB to the CONFIG_DB and the jinja2_cache was deleted the LOGLEVEL_DB is not in use.
**- How I did it**
Removed the LOGLEVEL_DB from the SONiC code

**- How to verify it**
All tests were passed

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

