### PR TITLE
Remove error logging on "failed in fdb_vlanmac"

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -98,9 +98,6 @@ class FdbUpdater(MIBUpdater):
                 continue
 
             vlanmac = self.fdb_vlanmac(fdb)
-            if not vlanmac:
-                mibs.logger.error("SyncD 'ASIC_DB' includes invalid FDB_ENTRY '{}': failed in fdb_vlanmac().".format(fdb_str))
-                continue
             self.vlanmac_ifindex_map[vlanmac] = port_index
             self.vlanmac_ifindex_list.append(vlanmac)
         self.vlanmac_ifindex_list.sort()

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -99,6 +99,7 @@ class FdbUpdater(MIBUpdater):
 
             vlanmac = self.fdb_vlanmac(fdb)
             if not vlanmac:
+                mibs.logger.debug("SyncD 'ASIC_DB' includes invalid FDB_ENTRY '{}': failed in fdb_vlanmac().".format(fdb_str))
                 continue
             self.vlanmac_ifindex_map[vlanmac] = port_index
             self.vlanmac_ifindex_list.append(vlanmac)

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -98,6 +98,8 @@ class FdbUpdater(MIBUpdater):
                 continue
 
             vlanmac = self.fdb_vlanmac(fdb)
+            if not vlanmac:
+                continue
             self.vlanmac_ifindex_map[vlanmac] = port_index
             self.vlanmac_ifindex_list.append(vlanmac)
         self.vlanmac_ifindex_list.sort()


### PR DESCRIPTION

**- What I did**
It is considered normal that the dependences of FDB_ENTRY are temporarily not available.

**- How I did it**

**- How to verify it**

**- Description for the changelog**

