### PR TITLE
Don't cache the vlan-id if it is not valid from DB

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -31,7 +31,9 @@ class FdbUpdater(MIBUpdater):
                 vlan_id = Namespace.dbs_get_vlan_id_from_bvid(self.db_conn, fdb["bvid"])
                 if isinstance(vlan_id, bytes):
                     vlan_id = vlan_id.decode()
-                self.bvid_vlan_map[fdb["bvid"]] = vlan_id
+                # only cache vlan_id if valid
+                if vlan_id is not None:
+                    self.bvid_vlan_map[fdb["bvid"]] = vlan_id
         else:
             return None
         if not isinstance(vlan_id, str):


### PR DESCRIPTION
Don't cache the vlan-id if it is not valid from DB

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Avoid caching the vlan-id with invalid value.

**- How I did it**
Add a check in code so if vlan-id is not valid, don't cache it.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

