### PR TITLE
[chassis]: Register only relevant MIBs on Supervisor

### DIFF
--- a/src/sonic_ax_impl/main.py
+++ b/src/sonic_ax_impl/main.py
@@ -13,6 +13,7 @@ from sonic_ax_impl.mibs import ieee802_1ab, Namespace
 from . import logger
 from .mibs.ietf import rfc1213, rfc2737, rfc2863, rfc3433, rfc4292, rfc4363
 from .mibs.vendor import dell, cisco
+from sonic_py_common import device_info
 
 # Background task update frequency ( in seconds )
 DEFAULT_UPDATE_FREQUENCY = 5
@@ -20,27 +21,30 @@ DEFAULT_UPDATE_FREQUENCY = 5
 event_loop = asyncio.get_event_loop()
 shutdown_task = None
 
+if not device_info.is_supervisor():
+    sonicMIB_list = (rfc1213.InterfacesMIB, rfc1213.IpMib, rfc1213.SysNameMIB, \
+                     rfc2737.PhysicalTableMIB, rfc3433.PhysicalSensorTableMIB, \
+                     rfc2863.InterfaceMIBObjects, rfc4363.QBridgeMIBObjects, \
+                     rfc4292.IpCidrRouteTable, \
+                     ieee802_1ab.LLDPLocalSystemData, ieee802_1ab.LLDPLocalSystemData.LLDPLocPortTable, \
+                     ieee802_1ab.LLDPLocalSystemData.LLDPLocManAddrTable, ieee802_1ab.LLDPRemTable,
+                     ieee802_1ab.LLDPRemManAddrTable, \
+                     dell.force10.SSeriesMIB, cisco.mgmt.CiscoSystemExtMIB, \
+                     cisco.bgp4.CiscoBgp4MIB, \
+                     cisco.ciscoPfcExtMIB.cpfcIfTable, cisco.ciscoPfcExtMIB.cpfcIfPriorityTable, \
+                     cisco.ciscoSwitchQosMIB.csqIfQosGroupStatsTable, cisco.ciscoEntityFruControlMIB.cefcFruPowerStatusTable)
+else:
+    sonicMIB_list = (rfc1213.InterfacesMIB, rfc1213.SysNameMIB, \
+                     rfc2737.PhysicalTableMIB, rfc3433.PhysicalSensorTableMIB, \
+                     rfc2863.InterfaceMIBObjects, rfc4363.QBridgeMIBObjects, \
+                     ieee802_1ab.LLDPLocalSystemData,
+                     ieee802_1ab.LLDPLocalSystemData.LLDPLocManAddrTable, ieee802_1ab.LLDPRemManAddrTable, \
+                     dell.force10.SSeriesMIB, cisco.mgmt.CiscoSystemExtMIB, \
+                     cisco.ciscoPfcExtMIB.cpfcIfTable, cisco.ciscoPfcExtMIB.cpfcIfPriorityTable, \
+                     cisco.ciscoSwitchQosMIB.csqIfQosGroupStatsTable, cisco.ciscoEntityFruControlMIB.cefcFruPowerStatusTable)
 
 class SonicMIB(
-    rfc1213.InterfacesMIB,
-    rfc1213.IpMib,
-    rfc1213.SysNameMIB,
-    rfc2737.PhysicalTableMIB,
-    rfc3433.PhysicalSensorTableMIB,
-    rfc2863.InterfaceMIBObjects,
-    rfc4363.QBridgeMIBObjects,
-    rfc4292.IpCidrRouteTable,
-    ieee802_1ab.LLDPLocalSystemData,
-    ieee802_1ab.LLDPLocalSystemData.LLDPLocPortTable,
-    ieee802_1ab.LLDPLocalSystemData.LLDPLocManAddrTable,
-    ieee802_1ab.LLDPRemTable,
-    ieee802_1ab.LLDPRemManAddrTable,
-    dell.force10.SSeriesMIB,
-    cisco.bgp4.CiscoBgp4MIB,
-    cisco.ciscoPfcExtMIB.cpfcIfTable,
-    cisco.ciscoPfcExtMIB.cpfcIfPriorityTable,
-    cisco.ciscoSwitchQosMIB.csqIfQosGroupStatsTable,
-    cisco.ciscoEntityFruControlMIB.cefcFruPowerStatusTable,
+    *sonicMIB_list
 ):
     """
     If SONiC was to create custom MIBEntries, they may be specified here.

--- a/src/sonic_ax_impl/main.py
+++ b/src/sonic_ax_impl/main.py
@@ -29,7 +29,7 @@ if not device_info.is_supervisor():
                      ieee802_1ab.LLDPLocalSystemData, ieee802_1ab.LLDPLocalSystemData.LLDPLocPortTable, \
                      ieee802_1ab.LLDPLocalSystemData.LLDPLocManAddrTable, ieee802_1ab.LLDPRemTable,
                      ieee802_1ab.LLDPRemManAddrTable, \
-                     dell.force10.SSeriesMIB, cisco.mgmt.CiscoSystemExtMIB, \
+                     dell.force10.SSeriesMIB, \
                      cisco.bgp4.CiscoBgp4MIB, \
                      cisco.ciscoPfcExtMIB.cpfcIfTable, cisco.ciscoPfcExtMIB.cpfcIfPriorityTable, \
                      cisco.ciscoSwitchQosMIB.csqIfQosGroupStatsTable, cisco.ciscoEntityFruControlMIB.cefcFruPowerStatusTable)
@@ -39,7 +39,7 @@ else:
                      rfc2863.InterfaceMIBObjects, rfc4363.QBridgeMIBObjects, \
                      ieee802_1ab.LLDPLocalSystemData,
                      ieee802_1ab.LLDPLocalSystemData.LLDPLocManAddrTable, ieee802_1ab.LLDPRemManAddrTable, \
-                     dell.force10.SSeriesMIB, cisco.mgmt.CiscoSystemExtMIB, \
+                     dell.force10.SSeriesMIB, \
                      cisco.ciscoPfcExtMIB.cpfcIfTable, cisco.ciscoPfcExtMIB.cpfcIfPriorityTable, \
                      cisco.ciscoSwitchQosMIB.csqIfQosGroupStatsTable, cisco.ciscoEntityFruControlMIB.cefcFruPowerStatusTable)
 


### PR DESCRIPTION
This is done to reduce CPU usage of snmp_ax_impl to avoid seeing socket connection failure seen during snmp query sent to supervisor of Chassis platform.

Signed-off-by: Suvarna Meenakshi <sumeenak@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
With packet-chassis Supervisor, we are seeing an issue where sending a SNMP query causes snmp_ax_impl-snmpd socket connection to break.
This is causing the SNMP result to error out with packet error or timeout.

This is because with packet-chassis Supervisor, we have 16 asics and we have interfaces data coming from each asic.
With periodic polling of all these interfaces data from each namespace is causing snmp agent to be busy and processing query and getting periodic data is causing snmp socket connection to break with snmpd.

To avoid this, this PR is to register only the MIBs that are relevant on Supervisor for Chassis.
We only need interfaces/CPU/platform modules related information. We will not need the LLDP/Route/BGP related information from Supervisor or they will not even be present.
Though the data is not present, many MIB periodic function rely on getting all interfaces data (sync_d functions).
By only registering the relevant MIBs, I could see the CPU usage of snmp_ax_impl going down and socket connection also does not break.
**- How I did it**
If device is supervisor, register MIBs relevant for Supervisor.
**- How to verify it**
Verified that packet-chassis sup does not see any socket connection error.
No change on - single asic/multi-asic/linecard modules.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

