### PR TITLE
Fixing the IfIndex MIB in sub-agent to starts from 1 for front panel ports

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -310,7 +310,7 @@ class InterfacesUpdater(MIBUpdater):
         :return: the 0-based interface ID.
         """
         if sub_id:
-            return self.get_oid(sub_id) - 1
+            return self.get_oid(sub_id)
 
     def interface_description(self, sub_id):
         """


### PR DESCRIPTION
**- Why I did it**
To fix https://github.com/sonic-net/sonic-buildimage/issues/13049 where the IfIndex starts from 0 for front panel ports

**- What I did**
Updated if_index() method from InterfacesUpdater() class to return the actual value and skip subtracting 1 from it.

**- How to verify it**
show ip int
Interface    Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
##############################################################
Ethernet128            172.21.235.128/31    up/up         N/A             N/A
Ethernet136            172.21.235.130/31    up/down       N/A             N/A
Ethernet144            172.21.235.132/31    up/up         N/A             N/A
Ethernet152            172.21.235.134/31    up/down       N/A             N/A
Ethernet160            172.21.235.136/31    up/down       N/A             N/A
Ethernet168            172.21.235.138/31    up/down       N/A             N/A
Ethernet176            172.21.235.140/31    up/up         N/A             N/A
Ethernet184            172.21.235.142/31    up/down       N/A             N/A
Ethernet192            172.21.235.144/31    up/down       N/A             N/A
Ethernet200            172.21.235.146/31    up/down       N/A             N/A
Ethernet208            172.21.235.148/31    up/down       N/A             N/A
Ethernet216            172.21.235.150/31    up/down       N/A             N/A
Ethernet224            172.21.235.152/31    up/down       N/A             N/A
Ethernet232            172.21.235.154/31    up/down       N/A             N/A
Ethernet240            172.21.235.156/31    up/down       N/A             N/A
Ethernet248            172.21.235.158/31    up/down       N/A             N/A
Loopback0              172.21.240.68/32     up/up         N/A             N/A
docker0                240.127.1.1/24       up/down       N/A             N/A
eth0         mgmt      100.126.16.40/25     up/up         N/A             N/A
lo                     127.0.0.1/16         up/up         N/A             N/A
lo-m         mgmt      127.0.0.1/16         up/up         N/A             N/A




show int status
  Interface                            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                                             Type    Asym PFC
###############################################################################################
  Ethernet0          89,90,91,92,93,94,95,96     400G   9212     rs     Eth1  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
  Ethernet8          81,82,83,84,85,86,87,88     400G   9212     rs     Eth2  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet16          73,74,75,76,77,78,79,80     400G   9212     rs     Eth3  routed    down       up                                              N/A         N/A
 Ethernet24          65,66,67,68,69,70,71,72     400G   9212     rs     Eth4  routed    down       up                                              N/A         N/A
 Ethernet32          57,58,59,60,61,62,63,64     400G   9212     rs     Eth5  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet40          49,50,51,52,53,54,55,56     400G   9212     rs     Eth6  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
 Ethernet48          41,42,43,44,45,46,47,48     400G   9212     rs     Eth7  routed    down       up                                              N/A         N/A
 Ethernet56          33,34,35,36,37,38,39,40     400G   9212     rs     Eth8  routed    down       up                                              N/A         N/A
 Ethernet64  153,154,155,156,157,158,159,160     400G   9212     rs     Eth9  routed    down       up                                              N/A         N/A
 Ethernet72  145,146,147,148,149,150,151,152     400G   9212     rs    Eth10  routed    down       up                                              N/A         N/A
 Ethernet80  137,138,139,140,141,142,143,144     400G   9212     rs    Eth11  routed    down       up                                              N/A         N/A
 Ethernet88  129,130,131,132,133,134,135,136     400G   9212     rs    Eth12  routed    down       up                                              N/A         N/A
 Ethernet96  121,122,123,124,125,126,127,128     400G   9212     rs    Eth13  routed    down       up                                              N/A         N/A
Ethernet104  113,114,115,116,117,118,119,120     400G   9212     rs    Eth14  routed    down       up                                              N/A         N/A
Ethernet112  105,106,107,108,109,110,111,112     400G   9212     rs    Eth15  routed    down       up                                              N/A         N/A
Ethernet120     97,98,99,100,101,102,103,104     400G   9212     rs    Eth16  routed    down       up                                              N/A         N/A
Ethernet128  209,210,211,212,213,214,215,216     400G   9212     rs    Eth17  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
Ethernet136  217,218,219,220,221,222,223,224     400G   9212     rs    Eth18  routed    down       up                                              N/A         N/A
Ethernet144  193,194,195,196,197,198,199,200     400G   9212     rs    Eth19  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
Ethernet152  201,202,203,204,205,206,207,208     400G   9212     rs    Eth20  routed    down       up                                              N/A         N/A
Ethernet160  177,178,179,180,181,182,183,184     400G   9212     rs    Eth21  routed    down       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
Ethernet168  185,186,187,188,189,190,191,192     400G   9212     rs    Eth22  routed    down       up                                              N/A         N/A
Ethernet176  161,162,163,164,165,166,167,168     400G   9212     rs    Eth23  routed      up       up  QSFP-DD Double Density 8X Pluggable Transceiver         N/A
Ethernet184  169,170,171,172,173,174,175,176     400G   9212     rs    Eth24  routed    down       up                                              N/A         N/A
Ethernet192          17,18,19,20,21,22,23,24     400G   9212     rs    Eth25  routed    down       up                                              N/A         N/A
Ethernet200          25,26,27,28,29,30,31,32     400G   9212     rs    Eth26  routed    down       up                                              N/A         N/A
Ethernet208                  1,2,3,4,5,6,7,8     400G   9212     rs    Eth27  routed    down       up                                              N/A         N/A
Ethernet216           9,10,11,12,13,14,15,16     400G   9212     rs    Eth28  routed    down       up                                              N/A         N/A
Ethernet224  241,242,243,244,245,246,247,248     400G   9212     rs    Eth29  routed    down       up                                              N/A         N/A
Ethernet232  249,250,251,252,253,254,255,256     400G   9212     rs    Eth30  routed    down       up                                              N/A         N/A
Ethernet240  225,226,227,228,229,230,231,232     400G   9212     rs    Eth31  routed    down       up                                              N/A         N/A
Ethernet248  233,234,235,236,237,238,239,240     400G   9212     rs    Eth32  routed    down       up                                              N/A         N/A


snmpwalk -v2c -c localhost 1.3.6.1.2.1.4.34.1.3.1
iso.3.6.1.2.1.2.2.1.1.1 = INTEGER: 1
iso.3.6.1.2.1.2.2.1.1.9 = INTEGER: 9
iso.3.6.1.2.1.2.2.1.1.17 = INTEGER: 17
iso.3.6.1.2.1.2.2.1.1.25 = INTEGER: 25
iso.3.6.1.2.1.2.2.1.1.33 = INTEGER: 33
iso.3.6.1.2.1.2.2.1.1.41 = INTEGER: 41
iso.3.6.1.2.1.2.2.1.1.49 = INTEGER: 49
iso.3.6.1.2.1.2.2.1.1.57 = INTEGER: 57
iso.3.6.1.2.1.2.2.1.1.65 = INTEGER: 65
iso.3.6.1.2.1.2.2.1.1.73 = INTEGER: 73
iso.3.6.1.2.1.2.2.1.1.81 = INTEGER: 81
iso.3.6.1.2.1.2.2.1.1.89 = INTEGER: 89
iso.3.6.1.2.1.2.2.1.1.97 = INTEGER: 97
iso.3.6.1.2.1.2.2.1.1.105 = INTEGER: 105
iso.3.6.1.2.1.2.2.1.1.113 = INTEGER: 113
iso.3.6.1.2.1.2.2.1.1.121 = INTEGER: 121
iso.3.6.1.2.1.2.2.1.1.129 = INTEGER: 129
iso.3.6.1.2.1.2.2.1.1.137 = INTEGER: 137
iso.3.6.1.2.1.2.2.1.1.145 = INTEGER: 145
iso.3.6.1.2.1.2.2.1.1.153 = INTEGER: 153
iso.3.6.1.2.1.2.2.1.1.161 = INTEGER: 161
iso.3.6.1.2.1.2.2.1.1.169 = INTEGER: 169
iso.3.6.1.2.1.2.2.1.1.177 = INTEGER: 177
iso.3.6.1.2.1.2.2.1.1.185 = INTEGER: 185
iso.3.6.1.2.1.2.2.1.1.193 = INTEGER: 193
iso.3.6.1.2.1.2.2.1.1.201 = INTEGER: 201
iso.3.6.1.2.1.2.2.1.1.209 = INTEGER: 209
iso.3.6.1.2.1.2.2.1.1.217 = INTEGER: 217
iso.3.6.1.2.1.2.2.1.1.225 = INTEGER: 225
iso.3.6.1.2.1.2.2.1.1.233 = INTEGER: 233
iso.3.6.1.2.1.2.2.1.1.241 = INTEGER: 241
iso.3.6.1.2.1.2.2.1.1.249 = INTEGER: 249
iso.3.6.1.2.1.2.2.1.1.10000 = INTEGER: 10000
iso.3.6.1.2.1.2.2.1.1.20000 = INTEGER: 20000

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

