### PR TITLE
Fixed issue#15359 by adding support of IpaddrToIfIndex MIB

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -1,3 +1,5 @@
+import os
+import re
 import ipaddress
 import python_arptable
 import socket
@@ -176,6 +178,83 @@ class NextHopUpdater(MIBUpdater):
 
         return self.route_list[right]
 
+class IfIndexUpdater(MIBUpdater):
+    def __init__(self):
+        super().__init__()
+        self.db_conn = Namespace.init_namespace_dbs()
+        self.if_index_map = {}
+        self.if_index_list = []
+
+    def _update_if_index_info(self, dev, ip):
+        if ip is None: return
+
+        if_index = mibs.get_index_from_str(dev)
+        if if_index is None: return
+
+        try:
+            ipaddr = ipaddress.ip_address(ip)
+        except Exception as e:
+            mibs.logger.warning("Failed to convert IP address '{}', error: {}.".format(ip, e))
+            return
+
+        iptuple = ip2byte_tuple(ip)
+        ip_type = 1 if isinstance(ipaddr, ipaddress.IPv4Address) else 2
+        ip_len = 4 if isinstance(ipaddr, ipaddress.IPv4Address) else 16
+        subid = (ip_type, ip_len,) + iptuple
+        self.if_index_map[subid] = if_index
+        self.if_index_list.append(subid)
+
+    def update_data(self):
+        self.if_index_map = {}
+        self.if_index_list = []
+
+        interfaces = Namespace.dbs_keys(self.db_conn, mibs.APPL_DB, "INTF_TABLE:*")
+        for interface in interfaces:
+            ethTablePrefix = re.search(r"INTF_TABLE\:[A-Za-z]+[0-9]+\:[0-9.\:A-Fa-f]+", interface)
+            if ethTablePrefix is None:
+                continue
+            else:
+                dev = ethTablePrefix.group().split(':')[1]
+                ip = ':'.join(ethTablePrefix.group().split(':')[2:])
+            self._update_if_index_info(dev, ip)
+
+        mgmt_ipv4 = os.popen('ip addr show eth0').read().split("inet ")[1].split("/")[0]
+        if (len(mgmt_ipv4) != 0):
+            self._update_if_index_info("eth0", mgmt_ipv4)
+        mgmt_ipv6 = os.popen('ip addr show eth0').read().split("inet6 ")[1].split("/")[0]
+        if (len(mgmt_ipv6) != 0):
+            self._update_if_index_info("eth0", mgmt_ipv6)
+
+        ips = os.popen('ip addr show docker0').read().split("inet ")[1].split("scope")[0]
+        if (len(ips) != 0):
+            ipv4 = ips.split(" brd ")[0].split("/")[0]
+            self._update_if_index_info("docker0", ipv4)
+            brd = ips.split(" brd ")[1].split(" ")[0]
+            self._update_if_index_info("docker0", brd)
+
+        ipv6 = os.popen('ip addr show docker0').read().split("inet6 ")[1].split("/")[0]
+        if (len(ipv6) != 0):
+            self._update_if_index_info("docker0", ipv6)
+        ipv6 = os.popen('ip addr show docker0').read().split("inet6 ")[2].split("/")[0]
+        if (len(ipv6) != 0):
+            self._update_if_index_info("docker0", ipv6)
+
+        brdg = os.popen('ip addr show Bridge').read().split("inet6 ")[1].split("/")[0]
+        if (len(brdg) != 0):
+            self._update_if_index_info("docker0", brdg)
+
+        self.if_index_list.sort()
+
+    def get_if_index(self, sub_id):
+        return self.if_index_map.get(sub_id, None)
+
+    def get_next(self, sub_id):
+        right = bisect_right(self.if_index_list, sub_id)
+        if right >= len(self.if_index_list):
+            return None
+
+        return self.if_index_list[right]
+
 class IpMib(metaclass=MIBMeta, prefix='.1.3.6.1.2.1.4'):
     arp_updater = ArpUpdater()
     nexthop_updater = NextHopUpdater()
@@ -185,6 +264,9 @@ class IpMib(metaclass=MIBMeta, prefix='.1.3.6.1.2.1.4'):
 
     ipNetToMediaPhysAddress = \
         SubtreeMIBEntry('22.1.2', arp_updater, ValueType.OCTET_STRING, arp_updater.arp_dest)
+
+    ipNetToIfIndex = \
+        SubtreeMIBEntry('34.1.3', ifindex_updater, ValueType.INTEGER, ifindex_updater.get_if_index)
 
 class InterfacesUpdater(MIBUpdater):
 


### PR DESCRIPTION
**- What I did**
Added support of ipAddressIfIndex MIB [OID: OID 1.3.6.1.2.1.4.34.1.3] to fix [issue#15359](https://github.com/sonic-net/sonic-buildimage/issues/15359).

**- How I did it**
Updated rfc1213.py to add a support IfIndexUpdater() class which will eventually create a map between Ipaddress and the respective interface index.

**- How to verify it**
```
root@sonic:~# show ip int
Interface     Master    IPv4 address/mask    Admin/Oper    BGP Neighbor    Neighbor IP
------------  --------  -------------------  ------------  --------------  -------------
Ethernet0              172.21.227.120/31    up/up         N/A             N/A
Ethernet8              172.21.227.122/31    up/up         N/A             N/A
docker0                 240.127.1.1/24       up/down       N/A             N/A
eth0                    10.4.4.85/23         up/up         N/A             N/A
lo                      127.0.0.1/16         up/up         N/A             N/A

root@sonic:~# ip addr show docker0
5: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default 
    link/ether 02:42:b3:6d:c9:52 brd ff:ff:ff:ff:ff:ff
    inet 240.127.1.1/24 brd 240.127.1.255 scope global docker0
       valid_lft forever preferred_lft forever
    inet6 fd00::1/80 scope global 
       valid_lft forever preferred_lft forever
    inet6 fe80::1/64 scope link 
       valid_lft forever preferred_lft forever

root@sonic:~# ip addr show Bridge
42: Bridge: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 9100 qdisc noqueue state DOWN group default qlen 1000
    link/ether 00:30:64:6a:fa:a3 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::1837:a4ff:fed5:3cfd/64 scope link 
       valid_lft forever preferred_lft forever

root@sonic:/# snmpwalk -v2c -c <comm> localhost 1.3.6.1.2.1.4.34.1.3
iso.3.6.1.2.1.4.34.1.3.1.4.172.21.227.120 = INTEGER: 1
iso.3.6.1.2.1.4.34.1.3.1.4.172.21.227.122 = INTEGER: 9
iso.3.6.1.2.1.4.34.1.3.1.4.10.4.4.85 = INTEGER: 10000
iso.3.6.1.2.1.4.34.1.3.1.4.240.127.1.1 = INTEGER: 4000
iso.3.6.1.2.1.4.34.1.3.1.4.240.127.1.255 = INTEGER: 4000
iso.3.6.1.2.1.4.34.1.3.2.16.253.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1 = INTEGER: 4000
iso.3.6.1.2.1.4.34.1.3.2.16.254.128.0.0.0.0.0.0.0.0.0.0.0.0.0.1 = INTEGER: 4000
iso.3.6.1.2.1.4.34.1.3.2.16.254.128.0.0.0.0.0.0.2.48.100.255.254.106.250.163 = INTEGER: 10000
iso.3.6.1.2.1.4.34.1.3.2.16.254.128.0.0.0.0.0.0.24.55.164.255.254.213.60.253 = INTEGER: 4000
```
**- Description for the changelog**
To fix issue#15359, I have raised two PRs.
1.
2.
