### PR TITLE
Fix FdbUpdater crash when SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID attribute missing.

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,22 @@
+name: Semgrep
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - master
+      - '201[7-9][0-1][0-9]'
+      - '202[0-9][0-1][0-9]'
+
+jobs:
+  semgrep:
+    if: github.repository_owner == 'sonic-net'
+    name: Semgrep
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+    steps:
+      - uses: actions/checkout@v3
+      - run: semgrep ci
+        env:
+           SEMGREP_RULES: p/default

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -61,6 +61,7 @@ class FdbUpdater(MIBUpdater):
 
         self.if_bpid_map = Namespace.dbs_get_bridge_port_map(self.db_conn, mibs.ASIC_DB)
         self.bvid_vlan_map.clear()
+        self.broken_fdbs.clear()
 
     def update_data(self):
         """
@@ -90,9 +91,9 @@ class FdbUpdater(MIBUpdater):
             try:
                 bridge_port_id_attr = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"]
             except KeyError as e:
-                # Only write error log once
+                # Only write warning log once
                 if fdb_str not in self.broken_fdbs:
-                    mibs.logger.error("SyncD 'ASIC_DB' includes invalid FDB_ENTRY '{}': failed to get bridge_port_id, exception: {}".format(fdb_str, e))
+                    mibs.logger.warn("SyncD 'ASIC_DB' includes invalid FDB_ENTRY '{}': failed to get bridge_port_id, exception: {}".format(fdb_str, e))
                     self.broken_fdbs.append(fdb_str)
                 continue
 

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -20,6 +20,7 @@ class FdbUpdater(MIBUpdater):
         self.vlanmac_ifindex_list = []
         self.if_bpid_map = {}
         self.bvid_vlan_map = {}
+        self.broken_fdbs = []
 
     def fdb_vlanmac(self, fdb):
         if 'vlan' in fdb:
@@ -89,7 +90,10 @@ class FdbUpdater(MIBUpdater):
             try:
                 bridge_port_id_attr = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"]
             except KeyError as e:
-                mibs.logger.error("SyncD 'ASIC_DB' includes invalid FDB_ENTRY '{}': failed to get bridge_port_id, exception: {}".format(fdb_str, e))
+                # Only write error log once
+                if fdb_str not in self.broken_fdbs:
+                    mibs.logger.error("SyncD 'ASIC_DB' includes invalid FDB_ENTRY '{}': failed to get bridge_port_id, exception: {}".format(fdb_str, e))
+                    self.broken_fdbs.append(fdb_str)
                 continue
 
             # Example output: oid:0x3a000000000608

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -85,6 +85,7 @@ class FdbUpdater(MIBUpdater):
             if not ent:
                 continue
 
+            bridge_port_id = ""
             try:
                 # Example output: oid:0x3a000000000608
                 bridge_port_id = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][6:]

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -85,14 +85,15 @@ class FdbUpdater(MIBUpdater):
             if not ent:
                 continue
 
-            bridge_port_id = ""
+            bridge_port_id_attr = ""
             try:
-                # Example output: oid:0x3a000000000608
-                bridge_port_id = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][6:]
-            except:
-                mibs.logger.error("SyncD 'ASIC_DB' includes invalid FDB_ENTRY '{}': failed to get bridge_port_id.".format(fdb_str))
+                bridge_port_id_attr = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"]
+            except KeyError as e:
+                mibs.logger.error("SyncD 'ASIC_DB' includes invalid FDB_ENTRY '{}': failed to get bridge_port_id, exception: {}".format(fdb_str, e))
                 continue
 
+            # Example output: oid:0x3a000000000608
+            bridge_port_id = bridge_port_id_attr[6:]
             if bridge_port_id not in self.if_bpid_map:
                 continue
             port_id = self.if_bpid_map[bridge_port_id]

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -85,8 +85,13 @@ class FdbUpdater(MIBUpdater):
             if not ent:
                 continue
 
-            # Example output: oid:0x3a000000000608
-            bridge_port_id = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][6:]
+            try:
+                # Example output: oid:0x3a000000000608
+                bridge_port_id = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][6:]
+            except:
+                mibs.logger.error("SyncD 'ASIC_DB' includes invalid FDB_ENTRY '{}': failed to get bridge_port_id.".format(fdb_str))
+                continue
+
             if bridge_port_id not in self.if_bpid_map:
                 continue
             port_id = self.if_bpid_map[bridge_port_id]

--- a/tests/test_rfc4363.py
+++ b/tests/test_rfc4363.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from unittest import TestCase
+
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    import mock
+
+modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(modules_path, 'src'))
+
+from sonic_ax_impl.mibs.ietf.rfc4363 import FdbUpdater
+
+class TestFdbUpdater(TestCase):
+
+    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_keys', mock.MagicMock(return_value=(['ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY:{"bvid":"oid:0x26000000000b6c","mac":"60:45:BD:98:6F:48","switch_id":"oid:0x21000000000000"}'])))
+    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_all', mock.MagicMock(return_value=({"nexthop": "10.0.0.1,10.0.0.3", "ifname": "Ethernet0,Ethernet4"})))
+    def test_FdbUpdater_ent_bridge_port_id_attr_missing(self):
+        updater = FdbUpdater()
+
+        with mock.patch('sonic_ax_impl.mibs.logger.error') as mocked_error:
+            updater.update_data()
+            
+            # check warning
+            mocked_error.assert_called()
+
+        self.assertTrue(len(updater.vlanmac_ifindex_list) == 0)

--- a/tests/test_rfc4363.py
+++ b/tests/test_rfc4363.py
@@ -19,10 +19,10 @@ class TestFdbUpdater(TestCase):
     def test_FdbUpdater_ent_bridge_port_id_attr_missing(self):
         updater = FdbUpdater()
 
-        with mock.patch('sonic_ax_impl.mibs.logger.error') as mocked_error:
+        with mock.patch('sonic_ax_impl.mibs.logger.warn') as mocked_warn:
             updater.update_data()
             
             # check warning
-            mocked_error.assert_called()
+            mocked_warn.assert_called()
 
         self.assertTrue(len(updater.vlanmac_ifindex_list) == 0)


### PR DESCRIPTION
Fix FdbUpdater crash when SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID attribute missing.

#### Work item tracking
Microsoft ADO (number only): 16189251

**- What I did**
Fix FdbUpdater crash when SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID attribute missing.

**- How I did it**
Add try-catch block in rfc3463 FdbUpdater

**- How to verify it**
Manually test.
Pass all UT

**- Description for the changelog**
Fix FdbUpdater crash when SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID attribute missing.
