### PR TITLE
Fix pipeline no enough disk space to download artifact issue

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,13 +43,8 @@ stages:
         runVersion: 'latestFromBranch'
         runBranch: 'refs/heads/master'
         patterns: |
-          '**/target/debs/buster/libyang_*.deb'
-          '**/target/debs/buster/libswsscommon_*.deb'
-          '**/target/debs/buster/python3-swsscommon_*.deb'
-          '**/target/debs/buster/libnl-*.deb'
-          '**/target/debs/buster/libhiredis*.deb'
-          '**/target/python-wheels/buster/swsssdk*.whl'
-          '**/target/python-wheels/buster/onic_py_common-*.whl'
+          **/*.whl
+          **/*.deb
       displayName: "Download sonic buildimage"
 
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,14 @@ stages:
         artifact: sonic-buildimage.vs
         runVersion: 'latestFromBranch'
         runBranch: 'refs/heads/master'
+        patterns: |
+          '**/target/debs/buster/libyang_*.deb'
+          '**/target/debs/buster/libswsscommon_*.deb'
+          '**/target/debs/buster/python3-swsscommon_*.deb'
+          '**/target/debs/buster/libnl-*.deb'
+          '**/target/debs/buster/libhiredis*.deb'
+          '**/target/python-wheels/buster/swsssdk*.whl'
+          '**/target/python-wheels/buster/onic_py_common-*.whl'
       displayName: "Download sonic buildimage"
 
     - script: |


### PR DESCRIPTION
Fix pipeline no enough disk space to download artifact issue.

#### Work item tracking
Microsoft ADO (number only): 24624663

**- What I did**
Fix pipeline no enough disk space to download artifact issue.

**- How I did it**
Improve pipeline to only download *.deb and *.whl 

**- How to verify it**
Pass all UT

**- Description for the changelog**
Fix pipeline no enough disk space to download artifact issue.
