### PR TITLE
Fix key missing exception when invalied transiver info in STATE_DB

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc3433.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc3433.py
@@ -385,6 +385,7 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
         self.ent_phy_sensor_precision_map = {}
         self.ent_phy_sensor_value_map = {}
         self.ent_phy_sensor_oper_state_map = {}
+        self.broken_transceiver_info.clear()
 
         transceiver_dom_encoded = Namespace.dbs_keys(self.statedb, mibs.STATE_DB, self.TRANSCEIVER_DOM_KEY_PATTERN)
         if transceiver_dom_encoded:
@@ -423,18 +424,17 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
                      in STATE_DB, skipping".format(transceiver_dom_entry))
                 continue
 
-            # skip RJ45 port
             transceiver_info_entry_data = Namespace.dbs_get_all(self.statedb, mibs.STATE_DB, mibs.transceiver_info_table(interface))
-    
             if 'type' not in transceiver_info_entry_data:
                 # Only write error log once
                 if interface not in self.broken_transceiver_info:
-                    mibs.logger.error(
+                    mibs.logger.warn(
                         "Invalid interface {} in STATE_DB, \
                         attribute 'type' missing in transceiver_info '{}'".format(interface, transceiver_info_entry_data))
                     self.broken_transceiver_info.append(interface)
                 continue
 
+            # skip RJ45 port
             if  transceiver_info_entry_data['type'] == RJ45_PORT_TYPE:
                 continue
 

--- a/src/sonic_ax_impl/mibs/ietf/rfc3433.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc3433.py
@@ -385,7 +385,6 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
         self.ent_phy_sensor_precision_map = {}
         self.ent_phy_sensor_value_map = {}
         self.ent_phy_sensor_oper_state_map = {}
-        self.broken_transceiver_info.clear()
 
         transceiver_dom_encoded = Namespace.dbs_keys(self.statedb, mibs.STATE_DB, self.TRANSCEIVER_DOM_KEY_PATTERN)
         if transceiver_dom_encoded:

--- a/src/sonic_ax_impl/mibs/ietf/rfc3433.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc3433.py
@@ -372,6 +372,7 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
         self.fan_sensor = []
         self.psu_sensor = []
         self.thermal_sensor = []
+        self.broken_transceiver_info = []
 
     def reinit_data(self):
         """
@@ -424,6 +425,16 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
 
             # skip RJ45 port
             transceiver_info_entry_data = Namespace.dbs_get_all(self.statedb, mibs.STATE_DB, mibs.transceiver_info_table(interface))
+    
+            if 'type' not in transceiver_info_entry_data:
+                # Only write error log once
+                if interface not in self.broken_transceiver_info:
+                    mibs.logger.error(
+                        "Invalid interface {} in STATE_DB, \
+                        attribute 'type' missing in transceiver_info '{}'".format(interface, transceiver_info_entry_data))
+                    self.broken_transceiver_info.append(interface)
+                continue
+
             if  transceiver_info_entry_data['type'] == RJ45_PORT_TYPE:
                 continue
 

--- a/tests/test_rfc3433.py
+++ b/tests/test_rfc3433.py
@@ -19,10 +19,10 @@ class TestPhysicalSensorTableMIBUpdater(TestCase):
         updater = PhysicalSensorTableMIBUpdater()
         updater.transceiver_dom.append("TRANSCEIVER_INFO|Ethernet0")
 
-        with mock.patch('sonic_ax_impl.mibs.logger.error') as mocked_error:
+        with mock.patch('sonic_ax_impl.mibs.logger.warn') as mocked_warn:
             updater.update_data()
 
             # check warning
-            mocked_error.assert_called()
+            mocked_warn.assert_called()
 
         self.assertTrue(len(updater.sub_ids) == 0)

--- a/tests/test_rfc3433.py
+++ b/tests/test_rfc3433.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from unittest import TestCase
+
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    import mock
+
+modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(modules_path, 'src'))
+
+from sonic_ax_impl.mibs.ietf.rfc3433 import PhysicalSensorTableMIBUpdater
+
+class TestPhysicalSensorTableMIBUpdater(TestCase):
+
+    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_all', mock.MagicMock(return_value=({"hardwarerev": "1.0"})))
+    def test_PhysicalSensorTableMIBUpdater_transceiver_info_key_missing(self):
+        updater = PhysicalSensorTableMIBUpdater()
+        updater.transceiver_dom.append("TRANSCEIVER_INFO|Ethernet0")
+
+        with mock.patch('sonic_ax_impl.mibs.logger.error') as mocked_error:
+            updater.update_data()
+
+            # check warning
+            mocked_error.assert_called()
+
+        self.assertTrue(len(updater.sub_ids) == 0)


### PR DESCRIPTION
Fix PhysicalSensorTableMIBUpdater crash when 'type' attribute missing.

#### Work item tracking
Microsoft ADO (number only): 24869277

**- What I did**
Fix PhysicalSensorTableMIBUpdater crash when 'type' attribute missing.

**- How I did it**
Check 'type' attribute, if missing write error log in PhysicalSensorTableMIBUpdater.

**- How to verify it**
Manually test.
Pass all UT

**- Description for the changelog**
Fix PhysicalSensorTableMIBUpdater crash when 'type' attribute missing.
