### PR TITLE
Improve MIBUpdater to re-connect DBConnector when re-init data.

### DIFF
--- a/src/ax_interface/mib.py
+++ b/src/ax_interface/mib.py
@@ -36,7 +36,10 @@ class MIBUpdater:
                 # reinit internal structures
                 if self.update_counter > self.reinit_rate:
                     # reconnect when redis exception happen
-                    self.reinit_data(redis_exception_happen)
+                    if redis_exception_happen:
+                            self.reinit_connection()
+
+                    self.reinit_data()
                     self.update_counter = 0
                 else:
                     self.update_counter += 1
@@ -61,16 +64,13 @@ class MIBUpdater:
     def reinit_data(self):
         """
         Reinit task. Children may override this method.
-        Deprecated, new Children need override: reinit_data(self, reconnect=False)
         """
         return
 
-    def reinit_data(self, reconnect=False):
+    def reinit_connection(self):
         """
-        Reinit task. Children may override this method.
+        Reinit redis connection task. Children may override this method.
         """
-        # call reinit_data() if Children only override reinit_data(self)
-        self.reinit_data()
         return
 
     def update_data(self):

--- a/src/ax_interface/mib.py
+++ b/src/ax_interface/mib.py
@@ -43,9 +43,9 @@ class MIBUpdater:
                 # run the background update task
                 self.update_data()
                 self.redis_exception_happen = False
-            except RuntimeError as e:
+            except RuntimeError:
                 # Any unexpected exception or error, log it and keep running
-                logger.exception("MIBUpdater.start() caught an unexpected exception during update_data(), exception: {}".format(e))
+                logger.exception("MIBUpdater.start() caught an unexpected exception during update_data()")
                 # When redis server restart, swsscommon will throw swsscommon.RedisError, redis connection need re-initialize in reinit_data()
                 # TODO: change to swsscommon.RedisError
                 self.redis_exception_happen = True

--- a/src/ax_interface/mib.py
+++ b/src/ax_interface/mib.py
@@ -37,7 +37,7 @@ class MIBUpdater:
                 if self.update_counter > self.reinit_rate:
                     # reconnect when redis exception happen
                     if redis_exception_happen:
-                            self.reinit_connection()
+                        self.reinit_connection()
 
                     self.reinit_data()
                     self.update_counter = 0

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -135,7 +135,8 @@ class NextHopUpdater(MIBUpdater):
         self.route_list = []
 
     def reinit_data(self):
-        Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
+        if self.redis_exception_happen:
+            Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
 
     def update_data(self):
         """
@@ -223,7 +224,9 @@ class InterfacesUpdater(MIBUpdater):
         """
         Subclass update interface information
         """
-        Namespace.connect_namespace_dbs(self.db_conn)
+        if self.redis_exception_happen:
+            Namespace.connect_namespace_dbs(self.db_conn)
+
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -134,8 +134,8 @@ class NextHopUpdater(MIBUpdater):
         self.nexthop_map = {}
         self.route_list = []
 
-    def reinit_data(self):
-        if self.redis_exception_happen:
+    def reinit_data(self, reconnect=False):
+        if reconnect:
             Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
 
     def update_data(self):
@@ -220,11 +220,11 @@ class InterfacesUpdater(MIBUpdater):
 
         self.namespace_db_map = Namespace.get_namespace_db_map(self.db_conn)
 
-    def reinit_data(self):
+    def reinit_data(self, reconnect=False):
         """
         Subclass update interface information
         """
-        if self.redis_exception_happen:
+        if reconnect:
             Namespace.connect_namespace_dbs(self.db_conn)
 
         self.if_name_map, \

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -226,7 +226,6 @@ class InterfacesUpdater(MIBUpdater):
         """
         Subclass update interface information
         """
-
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -134,9 +134,8 @@ class NextHopUpdater(MIBUpdater):
         self.nexthop_map = {}
         self.route_list = []
 
-    def reinit_data(self, reconnect=False):
-        if reconnect:
-            Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
+    def reinit_connection(self):
+        Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
 
     def update_data(self):
         """
@@ -220,12 +219,13 @@ class InterfacesUpdater(MIBUpdater):
 
         self.namespace_db_map = Namespace.get_namespace_db_map(self.db_conn)
 
-    def reinit_data(self, reconnect=False):
+    def reinit_connection(self):
+        Namespace.connect_namespace_dbs(self.db_conn)
+
+    def reinit_data(self):
         """
         Subclass update interface information
         """
-        if reconnect:
-            Namespace.connect_namespace_dbs(self.db_conn)
 
         self.if_name_map, \
         self.if_alias_map, \

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -134,6 +134,9 @@ class NextHopUpdater(MIBUpdater):
         self.nexthop_map = {}
         self.route_list = []
 
+    def reinit_data(self):
+        Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
+
     def update_data(self):
         """
         Update redis (caches config)
@@ -220,6 +223,7 @@ class InterfacesUpdater(MIBUpdater):
         """
         Subclass update interface information
         """
+        Namespace.connect_namespace_dbs(self.db_conn)
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/ietf/rfc2737.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2737.py
@@ -267,7 +267,7 @@ class PhysicalTableMIBUpdater(MIBUpdater):
         """
         return [creator(self) for creator in PhysicalTableMIBUpdater.physical_entity_updater_types]
 
-    def reinit_data(self):
+    def reinit_data(self, reconnect=False):
         """
         Re-initialize all data.
         """
@@ -287,7 +287,7 @@ class PhysicalTableMIBUpdater(MIBUpdater):
         self.physical_name_to_oid_map = {}
         self.pending_resolve_parent_name_map = {}
 
-        if self.redis_exception_happen:
+        if reconnect:
             Namespace.connect_all_dbs(self.statedb, mibs.STATE_DB)
 
         device_metadata = mibs.get_device_metadata(self.statedb[0])

--- a/src/sonic_ax_impl/mibs/ietf/rfc2737.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2737.py
@@ -287,7 +287,9 @@ class PhysicalTableMIBUpdater(MIBUpdater):
         self.physical_name_to_oid_map = {}
         self.pending_resolve_parent_name_map = {}
 
-        Namespace.connect_all_dbs(self.statedb, mibs.STATE_DB)
+        if self.redis_exception_happen:
+            Namespace.connect_all_dbs(self.statedb, mibs.STATE_DB)
+
         device_metadata = mibs.get_device_metadata(self.statedb[0])
         chassis_sub_id = (CHASSIS_SUB_ID, )
         self.physical_entities = [chassis_sub_id]

--- a/src/sonic_ax_impl/mibs/ietf/rfc2737.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2737.py
@@ -267,7 +267,10 @@ class PhysicalTableMIBUpdater(MIBUpdater):
         """
         return [creator(self) for creator in PhysicalTableMIBUpdater.physical_entity_updater_types]
 
-    def reinit_data(self, reconnect=False):
+    def reinit_connection(self):
+        Namespace.connect_all_dbs(self.statedb, mibs.STATE_DB)
+
+    def reinit_data(self):
         """
         Re-initialize all data.
         """
@@ -286,9 +289,6 @@ class PhysicalTableMIBUpdater(MIBUpdater):
 
         self.physical_name_to_oid_map = {}
         self.pending_resolve_parent_name_map = {}
-
-        if reconnect:
-            Namespace.connect_all_dbs(self.statedb, mibs.STATE_DB)
 
         device_metadata = mibs.get_device_metadata(self.statedb[0])
         chassis_sub_id = (CHASSIS_SUB_ID, )

--- a/src/sonic_ax_impl/mibs/ietf/rfc2737.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2737.py
@@ -287,6 +287,7 @@ class PhysicalTableMIBUpdater(MIBUpdater):
         self.physical_name_to_oid_map = {}
         self.pending_resolve_parent_name_map = {}
 
+        Namespace.connect_all_dbs(self.statedb, mibs.STATE_DB)
         device_metadata = mibs.get_device_metadata(self.statedb[0])
         chassis_sub_id = (CHASSIS_SUB_ID, )
         self.physical_entities = [chassis_sub_id]

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -107,7 +107,9 @@ class InterfaceMIBUpdater(MIBUpdater):
         """
         Subclass update interface information
         """
-        Namespace.connect_namespace_dbs(self.db_conn)
+        if self.redis_exception_happen:
+            Namespace.connect_namespace_dbs(self.db_conn)
+
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -103,13 +103,13 @@ class InterfaceMIBUpdater(MIBUpdater):
 
         self.namespace_db_map = Namespace.get_namespace_db_map(self.db_conn)
 
-    def reinit_data(self, reconnect=False):
+    def reinit_connection(self):
+        Namespace.connect_namespace_dbs(self.db_conn)
+
+    def reinit_data(self):
         """
         Subclass update interface information
         """
-        if reconnect:
-            Namespace.connect_namespace_dbs(self.db_conn)
-
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -103,11 +103,11 @@ class InterfaceMIBUpdater(MIBUpdater):
 
         self.namespace_db_map = Namespace.get_namespace_db_map(self.db_conn)
 
-    def reinit_data(self):
+    def reinit_data(self, reconnect=False):
         """
         Subclass update interface information
         """
-        if self.redis_exception_happen:
+        if reconnect:
             Namespace.connect_namespace_dbs(self.db_conn)
 
         self.if_name_map, \

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -107,6 +107,7 @@ class InterfaceMIBUpdater(MIBUpdater):
         """
         Subclass update interface information
         """
+        Namespace.connect_namespace_dbs(self.db_conn)
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/ietf/rfc3433.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc3433.py
@@ -386,7 +386,9 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
         self.ent_phy_sensor_value_map = {}
         self.ent_phy_sensor_oper_state_map = {}
 
-        Namespace.connect_all_dbs(self.statedb, mibs.STATE_DB)
+        if self.redis_exception_happen:
+            Namespace.connect_all_dbs(self.statedb, mibs.STATE_DB)
+
         transceiver_dom_encoded = Namespace.dbs_keys(self.statedb, mibs.STATE_DB, self.TRANSCEIVER_DOM_KEY_PATTERN)
         if transceiver_dom_encoded:
             self.transceiver_dom = [entry for entry in transceiver_dom_encoded]

--- a/src/sonic_ax_impl/mibs/ietf/rfc3433.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc3433.py
@@ -374,7 +374,7 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
         self.thermal_sensor = []
         self.broken_transceiver_info = []
 
-    def reinit_data(self):
+    def reinit_data(self, reconnect=False):
         """
         Reinit data, clear cache
         """
@@ -386,7 +386,7 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
         self.ent_phy_sensor_value_map = {}
         self.ent_phy_sensor_oper_state_map = {}
 
-        if self.redis_exception_happen:
+        if reconnect:
             Namespace.connect_all_dbs(self.statedb, mibs.STATE_DB)
 
         transceiver_dom_encoded = Namespace.dbs_keys(self.statedb, mibs.STATE_DB, self.TRANSCEIVER_DOM_KEY_PATTERN)

--- a/src/sonic_ax_impl/mibs/ietf/rfc3433.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc3433.py
@@ -374,7 +374,10 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
         self.thermal_sensor = []
         self.broken_transceiver_info = []
 
-    def reinit_data(self, reconnect=False):
+    def reinit_connection(self):
+        Namespace.connect_all_dbs(self.statedb, mibs.STATE_DB)
+    
+    def reinit_data(self):
         """
         Reinit data, clear cache
         """
@@ -385,10 +388,6 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
         self.ent_phy_sensor_precision_map = {}
         self.ent_phy_sensor_value_map = {}
         self.ent_phy_sensor_oper_state_map = {}
-
-        if reconnect:
-            Namespace.connect_all_dbs(self.statedb, mibs.STATE_DB)
-
         transceiver_dom_encoded = Namespace.dbs_keys(self.statedb, mibs.STATE_DB, self.TRANSCEIVER_DOM_KEY_PATTERN)
         if transceiver_dom_encoded:
             self.transceiver_dom = [entry for entry in transceiver_dom_encoded]

--- a/src/sonic_ax_impl/mibs/ietf/rfc3433.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc3433.py
@@ -386,6 +386,7 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
         self.ent_phy_sensor_value_map = {}
         self.ent_phy_sensor_oper_state_map = {}
 
+        Namespace.connect_all_dbs(self.statedb, mibs.STATE_DB)
         transceiver_dom_encoded = Namespace.dbs_keys(self.statedb, mibs.STATE_DB, self.TRANSCEIVER_DOM_KEY_PATTERN)
         if transceiver_dom_encoded:
             self.transceiver_dom = [entry for entry in transceiver_dom_encoded]

--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -23,7 +23,9 @@ class RouteUpdater(MIBUpdater):
         """
         self.loips = {}
 
-        Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
+        if self.redis_exception_happen:
+            Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
+
         loopbacks = Namespace.dbs_keys(self.db_conn, mibs.APPL_DB, "INTF_TABLE:lo:*")
         if not loopbacks:
             return

--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -23,6 +23,7 @@ class RouteUpdater(MIBUpdater):
         """
         self.loips = {}
 
+        Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
         loopbacks = Namespace.dbs_keys(self.db_conn, mibs.APPL_DB, "INTF_TABLE:lo:*")
         if not loopbacks:
             return

--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -17,13 +17,13 @@ class RouteUpdater(MIBUpdater):
         ## loopback ip string -> ip address object
         self.loips = {}
 
-    def reinit_data(self):
+    def reinit_data(self, reconnect=False):
         """
         Subclass update loopback information
         """
         self.loips = {}
 
-        if self.redis_exception_happen:
+        if reconnect:
             Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
 
         loopbacks = Namespace.dbs_keys(self.db_conn, mibs.APPL_DB, "INTF_TABLE:lo:*")

--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -17,14 +17,14 @@ class RouteUpdater(MIBUpdater):
         ## loopback ip string -> ip address object
         self.loips = {}
 
-    def reinit_data(self, reconnect=False):
+    def reinit_connection(self):
+        Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
+
+    def reinit_data(self):
         """
         Subclass update loopback information
         """
         self.loips = {}
-
-        if reconnect:
-            Namespace.connect_all_dbs(self.db_conn, mibs.APPL_DB)
 
         loopbacks = Namespace.dbs_keys(self.db_conn, mibs.APPL_DB, "INTF_TABLE:lo:*")
         if not loopbacks:

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -45,7 +45,9 @@ class FdbUpdater(MIBUpdater):
         """
         Subclass update interface information
         """
-        Namespace.connect_namespace_dbs(self.db_conn)
+        if self.redis_exception_happen:
+            Namespace.connect_namespace_dbs(self.db_conn)
+
         (
             self.if_name_map,
             self.if_alias_map,

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -41,13 +41,13 @@ class FdbUpdater(MIBUpdater):
             return None
         return (int(vlan_id),) + mac_decimals(fdb["mac"])
 
+    def reinit_connection(self):
+        Namespace.connect_namespace_dbs(self.db_conn)
+
     def reinit_data(self, reconnect=False):
         """
         Subclass update interface information
         """
-        if reconnect:
-            Namespace.connect_namespace_dbs(self.db_conn)
-
         (
             self.if_name_map,
             self.if_alias_map,

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -44,7 +44,7 @@ class FdbUpdater(MIBUpdater):
     def reinit_connection(self):
         Namespace.connect_namespace_dbs(self.db_conn)
 
-    def reinit_data(self, reconnect=False):
+    def reinit_data(self):
         """
         Subclass update interface information
         """

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -45,6 +45,7 @@ class FdbUpdater(MIBUpdater):
         """
         Subclass update interface information
         """
+        Namespace.connect_namespace_dbs(self.db_conn)
         (
             self.if_name_map,
             self.if_alias_map,

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -41,11 +41,11 @@ class FdbUpdater(MIBUpdater):
             return None
         return (int(vlan_id),) + mac_decimals(fdb["mac"])
 
-    def reinit_data(self):
+    def reinit_data(self, reconnect=False):
         """
         Subclass update interface information
         """
-        if self.redis_exception_happen:
+        if reconnect:
             Namespace.connect_namespace_dbs(self.db_conn)
 
         (

--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py
@@ -28,11 +28,11 @@ class PfcUpdater(MIBUpdater):
         self.if_range = []
         self.namespace_db_map = Namespace.get_namespace_db_map(self.db_conn)
 
-    def reinit_data(self):
+    def reinit_data(self, reconnect=False):
         """
         Subclass update interface information
         """
-        if self.redis_exception_happen:
+        if reconnect:
             Namespace.connect_namespace_dbs(self.db_conn)
 
         self.if_name_map, \

--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py
@@ -28,13 +28,13 @@ class PfcUpdater(MIBUpdater):
         self.if_range = []
         self.namespace_db_map = Namespace.get_namespace_db_map(self.db_conn)
 
-    def reinit_data(self, reconnect=False):
+    def reinit_connection(self):
+        Namespace.connect_namespace_dbs(self.db_conn)
+
+    def reinit_data(self):
         """
         Subclass update interface information
         """
-        if reconnect:
-            Namespace.connect_namespace_dbs(self.db_conn)
-
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py
@@ -32,6 +32,7 @@ class PfcUpdater(MIBUpdater):
         """
         Subclass update interface information
         """
+        Namespace.connect_namespace_dbs(self.db_conn)
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py
@@ -32,7 +32,9 @@ class PfcUpdater(MIBUpdater):
         """
         Subclass update interface information
         """
-        Namespace.connect_namespace_dbs(self.db_conn)
+        if self.redis_exception_happen:
+            Namespace.connect_namespace_dbs(self.db_conn)
+
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
@@ -71,6 +71,7 @@ class QueueStatUpdater(MIBUpdater):
         """
         Subclass update interface information
         """
+        Namespace.connect_namespace_dbs(self.db_conn)
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
@@ -67,13 +67,13 @@ class QueueStatUpdater(MIBUpdater):
         self.port_index_namespace = {}
         self.namespace_db_map = Namespace.get_namespace_db_map(self.db_conn)
 
-    def reinit_data(self, reconnect=False):
+    def reinit_connection(self):
+        Namespace.connect_namespace_dbs(self.db_conn)
+
+    def reinit_data(self):
         """
         Subclass update interface information
         """
-        if reconnect:
-            Namespace.connect_namespace_dbs(self.db_conn)
-
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
@@ -67,11 +67,11 @@ class QueueStatUpdater(MIBUpdater):
         self.port_index_namespace = {}
         self.namespace_db_map = Namespace.get_namespace_db_map(self.db_conn)
 
-    def reinit_data(self):
+    def reinit_data(self, reconnect=False):
         """
         Subclass update interface information
         """
-        if self.redis_exception_happen:
+        if reconnect:
             Namespace.connect_namespace_dbs(self.db_conn)
 
         self.if_name_map, \

--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
@@ -71,7 +71,9 @@ class QueueStatUpdater(MIBUpdater):
         """
         Subclass update interface information
         """
-        Namespace.connect_namespace_dbs(self.db_conn)
+        if self.redis_exception_happen:
+            Namespace.connect_namespace_dbs(self.db_conn)
+
         self.if_name_map, \
         self.if_alias_map, \
         self.if_id_map, \

--- a/tests/test_rfc1213.py
+++ b/tests/test_rfc1213.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import sys
 from unittest import TestCase
@@ -11,6 +12,7 @@ modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(modules_path, 'src'))
 
 from sonic_ax_impl.mibs.ietf.rfc1213 import NextHopUpdater
+
 
 class TestNextHopUpdater(TestCase):
 
@@ -43,3 +45,39 @@ class TestNextHopUpdater(TestCase):
             mocked_warning.assert_has_calls(expected)
 
         self.assertTrue(len(updater.route_list) == 0)
+
+
+class TestNextHopUpdaterRedisException(TestCase):
+    def __init__(self, name):
+        super().__init__(name)
+        self.throw_exception = True
+        self.updater = NextHopUpdater()
+    
+    # setup mock method, throw exception when first time call it
+    def mock_dbs_keys(self, *args, **kwargs):
+        if self.throw_exception:
+            self.throw_exception = False
+            raise RuntimeError
+
+        self.updater.run_event.clear()
+        return None
+
+    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_all', mock.MagicMock(return_value=({"ifname": "Ethernet0,Ethernet4"})))
+    def test_NextHopUpdater_redis_exception(self):
+        with mock.patch('sonic_ax_impl.mibs.Namespace.dbs_keys', self.mock_dbs_keys):
+            with mock.patch('ax_interface.logger.exception') as mocked_exception:
+                self.updater.run_event.set()
+                self.updater.frequency = 1
+                self.updater.reinit_rate = 1
+                self.updater.update_counter = 1
+                loop = asyncio.get_event_loop()
+                loop.run_until_complete(self.updater.start())
+                loop.close()
+
+                # check warning
+                expected = [
+                    mock.call("MIBUpdater.start() caught an unexpected exception during update_data()")
+                ]
+                mocked_exception.assert_has_calls(expected)
+
+        self.assertTrue(len(self.updater.route_list) == 0)

--- a/tests/test_rfc1213.py
+++ b/tests/test_rfc1213.py
@@ -81,8 +81,6 @@ class TestNextHopUpdaterRedisException(TestCase):
                 ]
                 mocked_exception.assert_has_calls(expected)
 
-        self.assertTrue(self.updater.redis_exception_happen == False)
-
 
     @mock.patch('sonic_ax_impl.mibs.init_mgmt_interface_tables', mock.MagicMock(return_value=([{}, {}])))
     def test_InterfacesUpdater_re_init_redis_exception(self):
@@ -100,10 +98,9 @@ class TestNextHopUpdaterRedisException(TestCase):
             return [{}, {}, {}, {}, {}]
         
         updater = InterfacesUpdater()
-        updater.redis_exception_happen = True
         with mock.patch('sonic_ax_impl.mibs.Namespace.get_sync_d_from_all_namespace', mock_get_sync_d_from_all_namespace):
             with mock.patch('sonic_ax_impl.mibs.Namespace.connect_namespace_dbs') as connect_namespace_dbs:
-                updater.reinit_data()
+                updater.reinit_data(True)
 
                 # check re-init
                 connect_namespace_dbs.assert_called()

--- a/tests/test_rfc1213.py
+++ b/tests/test_rfc1213.py
@@ -12,7 +12,7 @@ else:
 modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(modules_path, 'src'))
 
-from sonic_ax_impl.mibs.ietf.rfc1213 import NextHopUpdater, InterfacesUpdater, ArpUpdater
+from sonic_ax_impl.mibs.ietf.rfc1213 import NextHopUpdater, InterfacesUpdater
 
 
 class TestNextHopUpdater(TestCase):

--- a/tests/test_rfc1213.py
+++ b/tests/test_rfc1213.py
@@ -12,7 +12,7 @@ else:
 modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(modules_path, 'src'))
 
-from sonic_ax_impl.mibs.ietf.rfc1213 import NextHopUpdater, InterfacesUpdater
+from sonic_ax_impl.mibs.ietf.rfc1213 import NextHopUpdater, InterfacesUpdater, ArpUpdater
 
 
 class TestNextHopUpdater(TestCase):
@@ -100,7 +100,8 @@ class TestNextHopUpdaterRedisException(TestCase):
         updater = InterfacesUpdater()
         with mock.patch('sonic_ax_impl.mibs.Namespace.get_sync_d_from_all_namespace', mock_get_sync_d_from_all_namespace):
             with mock.patch('sonic_ax_impl.mibs.Namespace.connect_namespace_dbs') as connect_namespace_dbs:
-                updater.reinit_data(True)
+                updater.reinit_connection()
+                updater.reinit_data()
 
                 # check re-init
                 connect_namespace_dbs.assert_called()

--- a/tests/test_rfc3433.py
+++ b/tests/test_rfc3433.py
@@ -26,3 +26,15 @@ class TestPhysicalSensorTableMIBUpdater(TestCase):
             mocked_warn.assert_called()
 
         self.assertTrue(len(updater.sub_ids) == 0)
+
+    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_keys', mock.MagicMock(return_value=(None)))
+    @mock.patch('swsscommon.swsscommon.SonicV2Connector.keys', mock.MagicMock(return_value=(None)))
+    def test_PhysicalSensorTableMIBUpdater_re_init_redis_exception(self):
+        updater = PhysicalSensorTableMIBUpdater()
+        updater.redis_exception_happen = True
+
+        with mock.patch('sonic_ax_impl.mibs.Namespace.connect_all_dbs') as connect_all_dbs:
+            updater.reinit_data()
+
+            # check re-init
+            connect_all_dbs.assert_called()

--- a/tests/test_rfc3433.py
+++ b/tests/test_rfc3433.py
@@ -31,10 +31,9 @@ class TestPhysicalSensorTableMIBUpdater(TestCase):
     @mock.patch('swsscommon.swsscommon.SonicV2Connector.keys', mock.MagicMock(return_value=(None)))
     def test_PhysicalSensorTableMIBUpdater_re_init_redis_exception(self):
         updater = PhysicalSensorTableMIBUpdater()
-        updater.redis_exception_happen = True
 
         with mock.patch('sonic_ax_impl.mibs.Namespace.connect_all_dbs') as connect_all_dbs:
-            updater.reinit_data()
+            updater.reinit_data(True)
 
             # check re-init
             connect_all_dbs.assert_called()

--- a/tests/test_rfc3433.py
+++ b/tests/test_rfc3433.py
@@ -33,7 +33,7 @@ class TestPhysicalSensorTableMIBUpdater(TestCase):
         updater = PhysicalSensorTableMIBUpdater()
 
         with mock.patch('sonic_ax_impl.mibs.Namespace.connect_all_dbs') as connect_all_dbs:
-            updater.reinit_data(True)
+            updater.reinit_connection()
 
             # check re-init
             connect_all_dbs.assert_called()

--- a/tests/test_rfc4292.py
+++ b/tests/test_rfc4292.py
@@ -59,3 +59,15 @@ class TestRouteUpdater(TestCase):
             mocked_warning.assert_has_calls(expected)
 
         self.assertTrue(len(updater.route_dest_list) == 0)
+
+
+    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_keys', mock.MagicMock(return_value=(None)))
+    def test_RouteUpdater_re_init_redis_exception(self):
+        updater = RouteUpdater()
+        updater.redis_exception_happen = True
+
+        with mock.patch('sonic_ax_impl.mibs.Namespace.connect_all_dbs') as connect_all_dbs:
+            updater.reinit_data()
+
+            # check re-init
+            connect_all_dbs.assert_called()

--- a/tests/test_rfc4292.py
+++ b/tests/test_rfc4292.py
@@ -66,7 +66,7 @@ class TestRouteUpdater(TestCase):
         updater = RouteUpdater()
 
         with mock.patch('sonic_ax_impl.mibs.Namespace.connect_all_dbs') as connect_all_dbs:
-            updater.reinit_data(True)
+            updater.reinit_connection()
 
             # check re-init
             connect_all_dbs.assert_called()

--- a/tests/test_rfc4292.py
+++ b/tests/test_rfc4292.py
@@ -64,10 +64,9 @@ class TestRouteUpdater(TestCase):
     @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_keys', mock.MagicMock(return_value=(None)))
     def test_RouteUpdater_re_init_redis_exception(self):
         updater = RouteUpdater()
-        updater.redis_exception_happen = True
 
         with mock.patch('sonic_ax_impl.mibs.Namespace.connect_all_dbs') as connect_all_dbs:
-            updater.reinit_data()
+            updater.reinit_data(True)
 
             # check re-init
             connect_all_dbs.assert_called()

--- a/tests/test_rfc4363.py
+++ b/tests/test_rfc4363.py
@@ -33,7 +33,6 @@ class TestFdbUpdater(TestCase):
     @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_bridge_port_map', mock.MagicMock(return_value=(None)))
     def test_RouteUpdater_re_init_redis_exception(self):
         updater = FdbUpdater()
-        updater.redis_exception_happen = True
 
         def mock_get_sync_d_from_all_namespace(per_namespace_func, db_conn):
             if per_namespace_func == sonic_ax_impl.mibs.init_sync_d_interface_tables:
@@ -43,7 +42,7 @@ class TestFdbUpdater(TestCase):
 
         with mock.patch('sonic_ax_impl.mibs.Namespace.get_sync_d_from_all_namespace', mock_get_sync_d_from_all_namespace):
             with mock.patch('sonic_ax_impl.mibs.Namespace.connect_namespace_dbs') as connect_namespace_dbs:
-                updater.reinit_data()
+                updater.reinit_data(True)
 
                 # check re-init
                 connect_namespace_dbs.assert_called()

--- a/tests/test_rfc4363.py
+++ b/tests/test_rfc4363.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import sonic_ax_impl
 from unittest import TestCase
 
 if sys.version_info.major == 3:
@@ -26,3 +27,23 @@ class TestFdbUpdater(TestCase):
             mocked_warn.assert_called()
 
         self.assertTrue(len(updater.vlanmac_ifindex_list) == 0)
+
+
+    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_keys', mock.MagicMock(return_value=(None)))
+    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_bridge_port_map', mock.MagicMock(return_value=(None)))
+    def test_RouteUpdater_re_init_redis_exception(self):
+        updater = FdbUpdater()
+        updater.redis_exception_happen = True
+
+        def mock_get_sync_d_from_all_namespace(per_namespace_func, db_conn):
+            if per_namespace_func == sonic_ax_impl.mibs.init_sync_d_interface_tables:
+                return [{}, {}, {}, {}]
+
+            return [{}, {}, {}, {}, {}]
+
+        with mock.patch('sonic_ax_impl.mibs.Namespace.get_sync_d_from_all_namespace', mock_get_sync_d_from_all_namespace):
+            with mock.patch('sonic_ax_impl.mibs.Namespace.connect_namespace_dbs') as connect_namespace_dbs:
+                updater.reinit_data()
+
+                # check re-init
+                connect_namespace_dbs.assert_called()

--- a/tests/test_rfc4363.py
+++ b/tests/test_rfc4363.py
@@ -42,7 +42,7 @@ class TestFdbUpdater(TestCase):
 
         with mock.patch('sonic_ax_impl.mibs.Namespace.get_sync_d_from_all_namespace', mock_get_sync_d_from_all_namespace):
             with mock.patch('sonic_ax_impl.mibs.Namespace.connect_namespace_dbs') as connect_namespace_dbs:
-                updater.reinit_data(True)
+                updater.reinit_connection()
 
                 # check re-init
                 connect_namespace_dbs.assert_called()


### PR DESCRIPTION
Improve MIBUpdater to re-connect DBConnector when re-init data.

#### Work item tracking
Microsoft ADO (number only): 24705208

**- What I did**
Fix when redis restart, some MIBUpdater's db connection will broken and keeps report error to syslog issue.

There will be following message repeat in syslog:
```
#012  File "/usr/local/lib/python3.7/dist-packages/sonic_ax_impl/mibs/ietf/rfc2737.py", line 674, in _update_per_namespace_data#
#012    msg = pubsub.get_message()#
#012  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1626, in get_message#
#012    return _swsscommon.PubSub_get_message(self, timeout)#
#012RuntimeError: RedisError: Failed to select, err=3: errstr=Server closed the connection
```

**- How I did it**
Re-connect DBConnector in every MIBUpdater's reinit_data method.

**- How to verify it**
Pass all UT

Manually test with following steps:
1. in database container kill redis server.
2. start redis in database container later:  service redis-server start
2. check syslog, confirm following log exist but now new log few minutes later after mibs re-init:

sudo cat /var/log/syslog | grep rfc2737.py | grep PubSub_get_message

Sep 22 03:30:17.223944 vlab-01 ERR snmp#snmp-subagent [ax_interface] ERROR: MIBUpdater.start() caught an unexpected exception during update_data()#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.9/dist-packages/ax_interface/mib.py", line 43, in start#012    self.update_data()#012  File "/usr/local/lib/python3.9/dist-packages/sonic_ax_impl/mibs/ietf/rfc2737.py", line 326, in update_data#012    updater.update_data(i, self.statedb[i])#012  File "/usr/local/lib/python3.9/dist-packages/sonic_ax_impl/mibs/ietf/rfc2737.py", line 666, in update_data#012    self._update_per_namespace_data(self.pub_sub_dict[db_index])#012  File "/usr/local/lib/python3.9/dist-packages/sonic_ax_impl/mibs/ietf/rfc2737.py", line 675, in _update_per_namespace_data#012    msg = pubsub.get_message()#012  File "/usr/lib/python3/dist-packages/swsscommon/swsscommon.py", line 1996, in get_message#012    return _swsscommon.PubSub_get_message(self, timeout, interrupt_on_signal)#012RuntimeError: RedisError: Failed to select, err=3: errstr=Server closed the connection


**- Description for the changelog**
Improve MIBUpdater to re-connect DBConnector when re-init data.
