### PR TITLE
Fix pipeline build break caused by libhredis remove from sonic-buildimage artifect. 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,8 +50,7 @@ stages:
     - script: |
         set -ex
         sudo apt-get -y purge libhiredis-dev libnl-3-dev libnl-route-3-dev
-        # install libhiredis here to avoid autoremove by purge
-        sudo apt-get -y libhiredis0.14
+        sudo apt-get -y install libhiredis0.14
         sudo dpkg -i ../target/debs/buster/{libyang_1.0.73_amd64.deb,libswsscommon_1.0.0_amd64.deb,python3-swsscommon_1.0.0_amd64.deb,libnl-3-200_*.deb,libnl-genl-3-200_*.deb,libnl-nf-3-200_*.deb,libnl-route-3-200_*.deb}
         sudo python3 -m pip install ../target/python-wheels/buster/swsssdk*-py3-*.whl
         sudo python3 -m pip install ../target/python-wheels/buster/sonic_py_common-1.0-py3-none-any.whl

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,8 +49,8 @@ stages:
 
     - script: |
         set -ex
-        sudo apt-get -y purge libhiredis-dev libnl-3-dev libnl-route-3-dev
-        sudo dpkg -i ../target/debs/buster/{libyang_1.0.73_amd64.deb,libswsscommon_1.0.0_amd64.deb,python3-swsscommon_1.0.0_amd64.deb,libnl-3-200_*.deb,libnl-genl-3-200_*.deb,libnl-nf-3-200_*.deb,libnl-route-3-200_*.deb,libhiredis0.14_*.deb}
+        sudo apt-get -y purge libhiredis-dev libnl-3-dev libnl-route-3-dev libhiredis0.14
+        sudo dpkg -i ../target/debs/buster/{libyang_1.0.73_amd64.deb,libswsscommon_1.0.0_amd64.deb,python3-swsscommon_1.0.0_amd64.deb,libnl-3-200_*.deb,libnl-genl-3-200_*.deb,libnl-nf-3-200_*.deb,libnl-route-3-200_*.deb}
         sudo python3 -m pip install ../target/python-wheels/buster/swsssdk*-py3-*.whl
         sudo python3 -m pip install ../target/python-wheels/buster/sonic_py_common-1.0-py3-none-any.whl
         python3 setup.py bdist_wheel

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,9 @@ stages:
 
     - script: |
         set -ex
-        sudo apt-get -y purge libhiredis-dev libnl-3-dev libnl-route-3-dev libhiredis0.14
+        sudo apt-get -y purge libhiredis-dev libnl-3-dev libnl-route-3-dev
+        # install libhiredis here to avoid autoremove by purge
+        sudo apt-get -y libhiredis0.14
         sudo dpkg -i ../target/debs/buster/{libyang_1.0.73_amd64.deb,libswsscommon_1.0.0_amd64.deb,python3-swsscommon_1.0.0_amd64.deb,libnl-3-200_*.deb,libnl-genl-3-200_*.deb,libnl-nf-3-200_*.deb,libnl-route-3-200_*.deb}
         sudo python3 -m pip install ../target/python-wheels/buster/swsssdk*-py3-*.whl
         sudo python3 -m pip install ../target/python-wheels/buster/sonic_py_common-1.0-py3-none-any.whl


### PR DESCRIPTION
Fix pipeline build break caused by libhredis remove from sonic-buildimage artifect.

Pipeline build break because sonic-buildimage repo not build libhredis by this PR: https://github.com/sonic-net/sonic-buildimage/pull/15633

**- What I did**
Fix pipeline build break caused by libhredis remove from sonic-buildimage artifect.

**- How I did it**
Install libhiredis0.14 from debian apt source.

**- How to verify it**
Pass all UT

**- Description for the changelog**
Fix pipeline build break caused by libhredis remove from sonic-buildimage artifect.
