### PR TITLE
Add unit test for IfHighSpeed with PortChannel with no member ports

### DIFF
--- a/tests/test_rfc2863.py
+++ b/tests/test_rfc2863.py
@@ -1,0 +1,68 @@
+import os
+import sys
+import sonic_ax_impl
+from unittest import TestCase
+
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    import mock
+
+modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(modules_path, 'src'))
+
+from sonic_ax_impl.mibs.ietf.rfc2863 import InterfaceMIBUpdater
+
+class TestInterfaceMIBUpdater(TestCase):
+
+    def mock_get_sync_d_from_all_namespace(per_namespace_func, dbs):
+        if per_namespace_func == sonic_ax_impl.mibs.init_sync_d_lag_tables:
+            return [{'PortChannel999': [], 'PortChannel103': ['Ethernet120']}, # lag_name_if_name_map
+                    {},
+                    {1999: 'PortChannel999', 1103: 'PortChannel103'}, # oid_lag_name_map
+                    {},
+                    {}]
+
+        if per_namespace_func == sonic_ax_impl.mibs.init_sync_d_interface_tables:
+            return [{},
+                    {},
+                    {},
+                    {121: 'Ethernet120'}]
+
+        return [{},{},{}]
+
+    def mock_lag_entry_table(lag_name):
+        if lag_name == "PortChannel103":
+            return "PORT_TABLE:Ethernet120"
+
+        return
+
+    def mock_dbs_get_all(dbs, db_name, hash, *args, **kwargs):
+        if hash == "PORT_TABLE:Ethernet120":
+            return {'admin_status': 'up', 'alias': 'fortyGigE0/120', 'description': 'ARISTA03T1:Ethernet1', 'index': '30', 'lanes': '101,102,103,104', 'mtu': '9100', 'oper_status': 'up', 'pfc_asym': 'off', 'speed': '40000', 'tpid': '0x8100'}
+
+        return
+
+    def mock_init_mgmt_interface_tables(db_conn):
+        return [{},{}]
+
+    @mock.patch('sonic_ax_impl.mibs.Namespace.get_sync_d_from_all_namespace', mock_get_sync_d_from_all_namespace)
+    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_all', mock_dbs_get_all)
+    @mock.patch('sonic_ax_impl.mibs.lag_entry_table', mock_lag_entry_table)
+    @mock.patch('sonic_ax_impl.mibs.init_mgmt_interface_tables', mock_init_mgmt_interface_tables)
+    def test_InterfaceMIBUpdater_get_high_speed(self):
+        updater = InterfaceMIBUpdater()
+
+        with mock.patch('sonic_ax_impl.mibs.logger.warning') as mocked_warning:
+            updater.reinit_data()
+            updater.update_data()
+            
+            # get speed of port-channel 103, OID is 1103
+            speed = updater.get_high_speed((1103,))
+            print("103 speed: {}".format(speed))
+            self.assertTrue(speed == 40000)
+            
+            # get speed of port-channel 999, OID is 1999
+            speed = updater.get_high_speed((1999,))
+            print("999 speed: {}".format(speed))
+            self.assertTrue(speed == 0)


### PR DESCRIPTION
Add unit test for IfHighSpeed with PortChannel with no member ports

#### Work item tracking
Microsoft ADO (number only): 25199873

**- What I did**
Add new UT cover InterfaceMIBUpdater.get_high_speed(), this will fix issue: https://github.com/sonic-net/sonic-snmpagent/issues/294

**- How I did it**
Add new UT and mock data to test InterfaceMIBUpdater.get_high_speed() with PortChannel with no member ports

**- How to verify it**
Pass all UT

**- Description for the changelog**
Add unit test of IfHighSpeed with PortChannel with no member ports
