### PR TITLE
[202012] Fix IfHighSpeed UT issue on 202012

### DIFF
--- a/tests/test_rfc2863.py
+++ b/tests/test_rfc2863.py
@@ -20,7 +20,6 @@ class TestInterfaceMIBUpdater(TestCase):
             return [{'PortChannel999': [], 'PortChannel103': ['Ethernet120']}, # lag_name_if_name_map
                     {},
                     {1999: 'PortChannel999', 1103: 'PortChannel103'}, # oid_lag_name_map
-                    {},
                     {}]
 
         if per_namespace_func == sonic_ax_impl.mibs.init_sync_d_interface_tables:


### PR DESCRIPTION
Fix IfHighSpeed UT issue on 202012

#### Work item tracking
Microsoft ADO (number only): 25199873

**- What I did**
Fix IfHighSpeed UT issue on 202012

**- How I did it**
Fix UT backport issue by remove unnecessary mock data.

**- How to verify it**
Pass all UT

**- Description for the changelog**
Fix IfHighSpeed UT issue on 202012
