### PR TITLE
Enable faulthandler to provide more fault information.

### DIFF
--- a/src/sonic_ax_impl/__init__.py
+++ b/src/sonic_ax_impl/__init__.py
@@ -1,9 +1,13 @@
 import json
 import logging.handlers
-
+import faulthandler
 
 # configure logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 logger.addHandler(logging.NullHandler())
 
+# enable faulthandler to provide more information for debug
+# after enable faulthandler, the file 'stderr' will be remembered by faulthandler:
+# https://docs.python.org/dev/library/faulthandler.html#issue-with-file-descriptors
+faulthandler.enable()


### PR DESCRIPTION
Enable faulthandler to provide more fault information.

#### Work item tracking
Microsoft ADO (number only): 17637258

**- What I did**
Enable faulthandler to provide more fault information.

**- How I did it**
Enable faulthandler when snmp-subagent startup.

**- How to verify it**
Pass all UT

**- Description for the changelog**
Enable faulthandler to provide more fault information.
