### PR TITLE
The SNMP OID for IFName '1.3.6.1.2.1.31.1.1.1.1' returns the interface alias. It should return the interface name as 'EthernetXXX'.

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -197,7 +197,7 @@ class InterfaceMIBUpdater(MIBUpdater):
         elif oid in self.vlan_oid_name_map:
             result = self.vlan_oid_name_map[oid]
         else:
-            result = self.if_alias_map[self.oid_name_map[oid]]
+            result = self.oid_name_map[oid]
 
         return result
     


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Change ifName in ifXTable from "EthX(PortY)" to "EthernetXXX".

**- How I did it**
Requests that ifName in ifXTable is interface name same as ones showed in "show interfaces status".

**- How to verify it**
Use snmpwalk command "snmpwalk -v 2c -c public <device_ip> 1.3.6.1.2.1.31.1.1.1.1" to get ifName and front ports' name should be EthernetXXX.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

