### PR TITLE
[ciscoPfcExtMIB]: Remove returning first intf index if subid is empty

### DIFF
--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py
@@ -70,9 +70,6 @@ class PfcUpdater(MIBUpdater):
         :return: the next sub id.
         """
         try:
-            if not sub_id:
-                return self.if_range[0]
-
             right = bisect_right(self.if_range, sub_id)
             if right >= len(self.if_range):
                 return None


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
When querying for PFC counters MIB cpfcIfTable if there is no interface present on the device, then there is an exception while handing get_next as the implementation tries to return the first index of an empty list.
This happens in case of VoQ chassis Supervisor where there are no interfaces present. 
Anytime a snmp query is made to cpfcIfTable 1.3.6.1.4.1.9.9.813.1.1, the exception message gets logged on the device.

**- How I did it**
Currently if sub_id is None, if_range[0] is returned. IF if_range is empty array this can cause an Exception.
Removed this check to avoid returning if_range[0].
The check "if not sub_id" is not required here.
right = bisect_right(self.if_range, sub_id) will handle if the sub_id is empty or if the if_range is empty by returning 0 index.

**- How to verify it**
Verified that no exception is logged upon query in VoQ chassis supervisor.
Other platforms like Linecard, single-asic device - no Change in the SNMP result.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

