### PR TITLE
[PSU]: Return number of PSU as zero for Chassis Linecard

### DIFF
--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoEntityFruControlMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoEntityFruControlMIB.py
@@ -1,6 +1,7 @@
 from enum import Enum, unique
 from sonic_ax_impl import mibs
 from ax_interface import MIBMeta, ValueType, SubtreeMIBEntry
+from sonic_py_common.device_info import is_chassis, is_supervisor
 
 CHASSIS_INFO_KEY_TEMPLATE = 'chassis {}'
 PSU_INFO_KEY_TEMPLATE = 'PSU {}'
@@ -59,6 +60,9 @@ class PowerStatusHandler:
         Get PSU number
         :return: the number of supported PSU
         """
+        if is_chassis() and not is_supervisor():
+            return 0
+
         chassis_name = CHASSIS_INFO_KEY_TEMPLATE.format(1)
         chassis_info = self.statedb.get_all(self.statedb.STATE_DB, mibs.chassis_info_table(chassis_name))
         num_psus = get_chassis_data(chassis_info)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
If SNMP query is sent to get the PSU details, implementation catches Exception on Chassis Linecard.
This Exception log message is seen for every SNMP query made and can cause many syslogs if continuous polling is done.
```
docker exec -it snmp snmpwalk -v2c -c <comm> 127.0.0.1 1.3.6.1.4.1.9.9.117.1.1.2.1
ERR snmp#snmp-subagent [sonic_ax_impl] ERROR: PowerStatusHandler._get_psu_index() caught an unexpected exception during _get_num_psus()#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.9/dist-packages/sonic_ax_impl/mibs/vendor/cisco/ciscoEntityFruControlMIB.py", line 101, in _get_psu_index#012    num_psus = self._get_num_psus()#012  File "/usr/local/lib/python3.9/dist-packages/sonic_ax_impl/mibs/vendor/cisco/ciscoEntityFruControlMIB.py", line 66, in _get_num_psus#012    return int(num_psus[0])#012ValueError: invalid literal for int() with base 10: ''
```
This error is seen because SNMP implementation expects num_psus to be present in CHASSIS_INFO table.
But on linecard num_psus is not present.
```
 sonic-db-cli STATE_DB hgetall  "CHASSIS_INFO|chassis 1"
{'serial': '...', 'model': '..', 'revision': '..'}
```
**- How I did it**
If SNMP query is made on Chassis Linecard, then return num_psus as 0.
No change on single asic device.
**- How to verify it**
Verified that no Exception is logged on Chassis Linecard, also added unit-tests.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

