### PR TITLE
Add capability to read resolv.conf for FQDN sysname

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -735,6 +735,22 @@ class sysNameUpdater(MIBUpdater):
         """
         Subclass update interface information
         """
+        # If hostname is already set to dot notation
+        if "." in self.hostname:
+            return self.hostname
+
+        try:
+            with open('/etc/resolv.conf', 'r') as fd_resolv:
+                for line in fd_resolv.readlines():
+                    if 'search' in line:
+                        domain = line.split()[1]
+                        return "{}.{}".format(self.hostname, domain)
+
+        except Exception:
+            # If error in reading data from file
+            mibs.logger.warning("Cannot read domain from /etc/resolv.conf Using"
+                                " {} in sysName".format(self.hostname))
+
         return self.hostname
 
 

--- a/tests/namespace/test_sysname.py
+++ b/tests/namespace/test_sysname.py
@@ -37,7 +37,8 @@ class TestGetNextPDU(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.OCTET_STRING)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(9, 0, 0, 0, (1, 3, 6, 1, 2, 1, 1, 5, 0))))
-        self.assertEqual(str(value0.data), 'namespace_hostname')
+        hostname_value = str(value0.data).split(".")[0]
+        self.assertEqual(str(hostname_value), 'namespace_hostname')
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_sysname.py
+++ b/tests/test_sysname.py
@@ -35,4 +35,5 @@ class TestGetNextPDU(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.OCTET_STRING)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(9, 0, 0, 0, (1, 3, 6, 1, 2, 1, 1, 5, 0))))
-        self.assertEqual(str(value0.data), 'test_hostname')
+        hostname_value = str(value0.data).split(".")[0]
+        self.assertEqual(str(hostname_value), 'test_hostname')


### PR DESCRIPTION
**- What I did**
Read domain name from /etc/resolv.conf and return FQDN value for sysName

**- How I did it**

- As default behaviour only hostname will be returned. If hostname configured in config_db is FQDN than that value will returned 
- If hostname in config_db is not FQDN and If there is a domain name in the /etc/resolv.conf. Domain name is read from the file and FQDN value is returned for sysName.

**- How to verify it**
snmpget -Oqv -v 2c -c 'public' <ip_address> 1.3.6.1.2.1.1.5.0

**- Description for the changelog**
Capability to read resolv.conf for FQDN sysname

