### PR TITLE
Obtain management port speed from system file

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -289,6 +289,15 @@ class InterfaceMIBUpdater(MIBUpdater):
 
         return Namespace.dbs_get_all(self.db_conn, db, if_table, blocking=True)
 
+    def _get_mgmt_speed(self, oid):
+        interface = self.mgmt_oid_name_map[oid]
+        try:
+            with open(f'/sys/class/net/{interface}/speed', 'r') as f:
+                speed = int(f.read().strip())
+                return speed
+        except:
+            return 0
+
     def get_high_speed(self, sub_id):
         """
         :param sub_id: The 1-based sub-identifier query.
@@ -297,6 +306,9 @@ class InterfaceMIBUpdater(MIBUpdater):
         oid = self.get_oid(sub_id)
         if not oid:
             return
+
+        if oid in self.mgmt_oid_name_map:
+            return self._get_mgmt_speed(oid)
 
         if oid in self.oid_lag_name_map:
             speed = 0

--- a/tests/namespace/test_hc_interfaces.py
+++ b/tests/namespace/test_hc_interfaces.py
@@ -9,6 +9,7 @@ modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(modules_path, 'src'))
 
 from unittest import TestCase
+from unittest.mock import patch, mock_open
 
 from ax_interface import ValueType
 from ax_interface.pdu import PDU
@@ -222,7 +223,8 @@ class TestGetNextPDU(TestCase):
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1, 10001))))
         self.assertEqual(str(value0.data), 'mgmt1')
 
-    def test_mgmt_iface_speed(self):
+    @patch("builtins.open", new_callable=mock_open, read_data="1000\n")
+    def test_mgmt_iface_speed(self, mock_file):
         """
         Test that mgmt port speed is 1000
         """

--- a/tests/test_hc_interfaces.py
+++ b/tests/test_hc_interfaces.py
@@ -9,6 +9,7 @@ modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(modules_path, 'src'))
 
 from unittest import TestCase
+from unittest.mock import patch, mock_open
 
 from ax_interface import ValueType
 from ax_interface.pdu import PDU
@@ -225,7 +226,8 @@ class TestGetNextPDU(TestCase):
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1, 10001))))
         self.assertEqual(str(value0.data), 'mgmt1')
 
-    def test_mgmt_iface_speed(self):
+    @patch("builtins.open", new_callable=mock_open, read_data="1000\n")
+    def test_mgmt_iface_speed(self, mock_file):
         """
         Test that mgmt port speed is 1000
         """


### PR DESCRIPTION
Obtain the actual management port speed from system file /sys/class/net/eth0/speed.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Currently the management port speed was obtained from the "speed" value in "MGMT_PORT" table of config_db. However, this field has no actual function.
This PR is to obtain the actual management port speed from system file "/sys/class/net/eth0/speed".

**- How I did it**
Add a function to obtain the actual management port speed from system file "/sys/class/net/eth0/speed".

**- How to verify it**
Run snmpwalk to get if high speed, make sure the management port speed is correct.

```
docker exec -it snmp snmpwalk -v2c -c public 127.0.0.1 1.3.6.1.2.1.31.1.1.1.15
iso.3.6.1.2.1.31.1.1.1.15.1 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.5 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.9 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.13 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.17 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.21 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.25 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.29 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.33 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.37 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.41 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.45 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.49 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.53 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.57 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.61 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.65 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.69 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.73 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.77 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.81 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.85 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.89 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.93 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.97 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.101 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.105 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.109 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.113 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.117 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.121 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.125 = Gauge32: 100000
iso.3.6.1.2.1.31.1.1.1.15.10000 = Gauge32: 1000
``` 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

