### PR TITLE
Fixes failure with unnumbered BGP neighours and don't report VLAN interfaces as down

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -530,7 +530,12 @@ class InterfacesUpdater(MIBUpdater):
         :param sub_id: The 1-based sub-identifier query.
         :return: oper state value for the respective sub_id.
         """
-        return self._get_status(sub_id, "oper_status")
+        if self.get_oid(sub_id) in self.vlan_oid_name_map:
+            # VLAN interfaces don't have an operational status, so return admin status for them
+            key = "admin_status"
+        else:
+            key = "oper_status"
+        return self._get_status(sub_id, key)
 
     def get_mtu(self, sub_id):
         """

--- a/src/sonic_ax_impl/mibs/vendor/cisco/bgp4.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/bgp4.py
@@ -39,7 +39,13 @@ class BgpSessionUpdater(MIBUpdater):
             neigh_info = self.db_conn[db_index].get_all(mibs.STATE_DB, neigh_key, blocking=False)
             if neigh_info:
                 state = neigh_info['state']
-                ip = ipaddress.ip_address(neigh_str)
+                try:
+                    ip = ipaddress.ip_address(neigh_str)
+                except ValueError:
+                    # In case of unnumbered BGP, the neighbor is an interface.
+                    # That can't be represented here, so just skip the neighbor.
+                    continue
+
                 if type(ip) is ipaddress.IPv4Address:
                     oid_head = (1, 4)
                 else:


### PR DESCRIPTION
**- What I did**

- Skip unnumbered BGP neighours instead of failing
- Don't report VLAN interfaces as oper_down

**- How I did it**

1. In case of unnumbered BGP, the neighbor is an interface.
That can't be represented here, so just skip the neighbor.
2. VLAN interfaces don't have an operational status, so 
return admin status for them

**- How to verify it**

1. Unnumbered BGP neighours no longer trigger a failure
2. VLAN Interfaces are no longer reported as down

**- Description for the changelog**

- Skip unnumbered BGP neighours instead of failing
- Don't report VLAN interfaces as oper_down
