### PR TITLE
Fix missing queues in SNMP MIB when create_only_db_buffers=true (test_snmp_queue_counters.py)

### DIFF
--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoSwitchQosMIB.py
@@ -149,6 +149,16 @@ class QueueStatUpdater(MIBUpdater):
             if pq_count < max_queues_half:
                 pq_count = max_queues_half
 
+            # Check number of priority groups (We may use this value if create_db_buffers_only removes intermediary queues eg. Ethernet0[3-4])
+            pg_max = 0;
+            buffer_parms = Namespace.dbs_get_all(self.db_conn, mibs.STATE_DB,
+                                                    mibs.buffer_max_parm_table(self.oid_name_map[if_index]))
+            if 'max_priority_groups' in buffer_parms:
+                pg_max = int(buffer_parms['max_priority_groups'])
+
+            if(pq_count < pg_max):
+                pq_count = pg_max
+
             for queue in if_queues:
                 # Get queue type and statistics
                 queue_sai_oid = self.port_queues_map[mibs.queue_key(if_index, queue)]


### PR DESCRIPTION
**- What I did**
This will fix current failure in test_snmp_queue_counters.py on platforms which have a different number of unicast and multicast queue (example Tomahawk4 with 8 unicast and 4 multicast queues configured)

**- How I did it**
Without these changes, when create_only_db_buffers=true and some intermediary interface queues are removed, SNMP MIB will be missing queues that are configured. 

The test failure specifically sees queues 1-7 on Ethernet0, then removes queues 3-4 on Ethernet0. Subsequent MIB polling returns only queues 1,2,5,6 (Missing queue 7).

Added some additional logic on top of changes made in https://github.com/sonic-net/sonic-snmpagent/pull/330 to also check for "max_priority_groups" in buffer_parms, and use it to loop through queues if it is greater than max_queues/2 (only 6 on TH4 platform which is what was fixed in #330) and greater than the count of UNICAST queues in the DB.

**- How to verify it**
Logic should not break other platforms. Verified on Nokia H4-64D. Reran all SNMP tests in mgmt and they pass including
test_snmp_queue_counters.py

**- Description for the changelog**
Fix missing queues in SNMP MIB when create_only_db_buffers=true

