### PR TITLE
snmpagent: modify entities to include fans under fabric module

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -96,6 +96,12 @@ def psu_info_table(psu_name):
 
     return "PSU_INFO" + TABLE_NAME_SEPARATOR_VBAR + psu_name
 
+def chassis_module_table(module_name):
+    """
+    :param module_name: module name
+    :return chassis module table entry for this module
+    """
+    return "CHASSIS_MODULE_TABLE" + TABLE_NAME_SEPARATOR_VBAR + module_name
 
 def physical_entity_info_table(name):
     """

--- a/src/sonic_ax_impl/mibs/ietf/physical_entity_sub_oid_generator.py
+++ b/src/sonic_ax_impl/mibs/ietf/physical_entity_sub_oid_generator.py
@@ -16,6 +16,7 @@ Module Type describes below:
 2 - Management
 5 - Fan Drawer
 6 - PSU
+7 - Fabric Card
 Device Type describes below:
 01 - PS
 02 - Fan
@@ -53,6 +54,7 @@ MODULE_INDEX_MULTIPLE = 1000000
 MODULE_TYPE_MGMT = 2 * MODULE_TYPE_MULTIPLE
 MODULE_TYPE_FAN_DRAWER = 5 * MODULE_TYPE_MULTIPLE
 MODULE_TYPE_PSU = 6 * MODULE_TYPE_MULTIPLE
+MODULE_TYPE_FABRIC_CARD = 7 * MODULE_TYPE_MULTIPLE
 MODULE_TYPE_PORT = 1000000000
 
 # Device Type Definition
@@ -119,6 +121,15 @@ def get_fan_drawer_sub_id(position):
     :return: sub OID of the fan drawer
     """
     return (MODULE_TYPE_FAN_DRAWER + position * MODULE_INDEX_MULTIPLE, )
+
+def get_fabric_card_sub_id(position):
+    """
+    Returns sub OID for fabric card. Sub OID is calculated as follows:
+    sub OID = MODULE_TYPE_FABRIC_CARD + position * MODULE_INDEX_MULTIPLE
+    :param position: fabric card position
+    :return: sub OID of the fabric card
+    """
+    return (MODULE_TYPE_FABRIC_CARD + position * MODULE_INDEX_MULTIPLE, )
 
 def get_fan_tachometers_sub_id(parent_id):
     """

--- a/src/sonic_ax_impl/mibs/ietf/rfc3433.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc3433.py
@@ -14,6 +14,7 @@ from .physical_entity_sub_oid_generator import CHASSIS_SUB_ID
 from .physical_entity_sub_oid_generator import get_transceiver_sensor_sub_id
 from .physical_entity_sub_oid_generator import get_fan_drawer_sub_id
 from .physical_entity_sub_oid_generator import get_fan_sub_id
+from .physical_entity_sub_oid_generator import get_fabric_card_sub_id
 from .physical_entity_sub_oid_generator import get_fan_tachometers_sub_id
 from .physical_entity_sub_oid_generator import get_psu_sub_id
 from .physical_entity_sub_oid_generator import get_psu_sensor_sub_id
@@ -23,6 +24,7 @@ from .sensor_data import ThermalSensorData, FANSensorData, PSUSensorData, Transc
 NOT_AVAILABLE = 'N/A'
 CHASSIS_NAME_SUB_STRING = 'chassis'
 PSU_NAME_SUB_STRING = 'PSU'
+FABRIC_CARD_NAME_SUB_STRING = 'FABRIC-CARD'
 RJ45_PORT_TYPE = 'RJ45'
 
 def is_null_empty_str(value):
@@ -536,6 +538,8 @@ class PhysicalSensorTableMIBUpdater(MIBUpdater):
 
                     if PSU_NAME_SUB_STRING in fan_parent_name:
                         fan_parent_sub_id = get_psu_sub_id(fan_parent_position)
+                    elif FABRIC_CARD_NAME_SUB_STRING in fan_parent_name:
+                        fan_parent_sub_id = get_fabric_card_sub_id(fan_parent_position)
                     else:
                         fan_parent_sub_id = get_fan_drawer_sub_id(fan_parent_position)
                 else:

--- a/tests/test_rfc2737.py
+++ b/tests/test_rfc2737.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 
 import pytest
 from sonic_ax_impl.mibs.ietf.rfc2737 import PhysicalTableMIBUpdater
-
+from sonic_ax_impl.mibs.ietf.rfc2737 import FabricCardCacheUpdater
 
 if sys.version_info.major == 3:
     from unittest import mock
@@ -30,6 +30,7 @@ class TestPhysicalTableMIBUpdater(TestCase):
               mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.FanDrawerCacheUpdater.reinit_data') as mocked_fan_drawer_reinit_data,
               mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.FanCacheUpdater.reinit_data') as mocked_fan_cache_reinit_data,
               mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.ThermalCacheUpdater.reinit_data') as mocked_thermal_reinit_data,
+              mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.FabricCardCacheUpdater.reinit_data') as mocked_fc_reinit_data,
               mock.patch('sonic_ax_impl.mibs.cancel_redis_pubsub') as mocked_cancel_redis_pubsub):
             updater.reinit_data()
             mocked_xcvr_reinit_data.assert_called()
@@ -37,6 +38,7 @@ class TestPhysicalTableMIBUpdater(TestCase):
             mocked_fan_drawer_reinit_data.assert_called()
             mocked_fan_cache_reinit_data.assert_called()
             mocked_thermal_reinit_data.assert_called()
+            mocked_fc_reinit_data.assert_called()
             mocked_cancel_redis_pubsub.assert_called()
         assert str(excinfo.value) == "[Exception('mocked error')]"
 
@@ -53,6 +55,7 @@ class TestPhysicalTableMIBUpdater(TestCase):
               mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.PsuCacheUpdater.reinit_data') as mocked_psu_reinit_data,
               mock.patch(
                   'sonic_ax_impl.mibs.ietf.rfc2737.FanDrawerCacheUpdater.reinit_data') as mocked_fan_drawer_reinit_data,
+              mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.FabricCardCacheUpdater.reinit_data') as mocked_fc_reinit_data,
               mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.FanCacheUpdater.reinit_data') as mocked_fan_cache_reinit_data,
               mock.patch('sonic_ax_impl.mibs.cancel_redis_pubsub') as mocked_cancel_redis_pubsub):
             updater.reinit_data()
@@ -60,6 +63,7 @@ class TestPhysicalTableMIBUpdater(TestCase):
             mocked_psu_reinit_data.assert_called()
             mocked_fan_drawer_reinit_data.assert_called()
             mocked_fan_cache_reinit_data.assert_called()
+            mocked_fc_reinit_data.assert_called()
             mocked_thermal_reinit_data.assert_called()
             mocked_cancel_redis_pubsub.assert_called()
         assert str(excinfo.value) == "[Exception('mocked error')]"
@@ -79,6 +83,7 @@ class TestPhysicalTableMIBUpdater(TestCase):
                   'sonic_ax_impl.mibs.ietf.rfc2737.FanDrawerCacheUpdater.reinit_data') as mocked_fan_drawer_reinit_data,
               mock.patch(
                   'sonic_ax_impl.mibs.ietf.rfc2737.FanCacheUpdater.reinit_data') as mocked_fan_cache_reinit_data,
+              mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.FabricCardCacheUpdater.reinit_data') as mocked_fc_reinit_data,
               mock.patch('sonic_ax_impl.mibs.cancel_redis_pubsub') as mocked_cancel_redis_pubsub):
             updater.reinit_data()
             mocked_thermal_reinit_data.assert_called()
@@ -86,6 +91,7 @@ class TestPhysicalTableMIBUpdater(TestCase):
             mocked_psu_reinit_data.assert_called()
             mocked_fan_drawer_reinit_data.assert_called()
             mocked_fan_cache_reinit_data.assert_called()
+            mocked_fc_reinit_data.assert_called()
             mocked_cancel_redis_pubsub.assert_called()
         assert str(excinfo.value) == "[RuntimeError('mocked runtime error')]"
 
@@ -102,6 +108,7 @@ class TestPhysicalTableMIBUpdater(TestCase):
               mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.FanDrawerCacheUpdater.reinit_data') as mocked_fan_drawer_reinit_data,
               mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.FanCacheUpdater.reinit_data') as mocked_fan_cache_reinit_data,
               mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.ThermalCacheUpdater.reinit_data') as mocked_thermal_reinit_data,
+              mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.FabricCardCacheUpdater.reinit_data') as mocked_fc_reinit_data,
               mock.patch('sonic_ax_impl.mibs.cancel_redis_pubsub') as mocked_cancel_redis_pubsub):
             updater.reinit_data()
             mocked_xcvr_reinit_data.assert_called()
@@ -109,6 +116,7 @@ class TestPhysicalTableMIBUpdater(TestCase):
             mocked_fan_drawer_reinit_data.assert_called()
             mocked_fan_cache_reinit_data.assert_called()
             mocked_thermal_reinit_data.assert_called()
+            mocked_fc_reinit_data.assert_called()
             mocked_cancel_redis_pubsub.assert_called()
         assert str(exc_info.value) == "[RuntimeError('mocked runtime error')]"
 
@@ -127,12 +135,29 @@ class TestPhysicalTableMIBUpdater(TestCase):
               mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.PsuCacheUpdater.reinit_data') as mocked_psu_reinit_data,
               mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.FanDrawerCacheUpdater.reinit_data') as mocked_fan_drawer_reinit_data,
               mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.FanCacheUpdater.reinit_data') as mocked_fan_cache_reinit_data,
+              mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.FabricCardCacheUpdater.reinit_data') as mocked_fc_reinit_data,
               mock.patch('sonic_ax_impl.mibs.cancel_redis_pubsub') as mocked_cancel_redis_pubsub):
             updater.reinit_data()
             mocked_xcvr_reinit_data.assert_called()
             mocked_psu_reinit_data.assert_called()
             mocked_fan_drawer_reinit_data.assert_called()
             mocked_fan_cache_reinit_data.assert_called()
+            mocked_fc_reinit_data.assert_called()
             mocked_thermal_reinit_data.assert_called()
             mocked_cancel_redis_pubsub.assert_called()
         assert str(exc_info.value) == "[RuntimeError('mocked runtime error'), Exception('mocked error')]"
+
+
+class TestFabricCardCacheUpdater(TestCase):
+    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_all', mock.MagicMock(return_value=({"model": "Model000", "presence": "True", "serial" : "Serial000", "is_replaceable" : "False"})))
+    @mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.PhysicalEntityCacheUpdater.get_physical_relation_info', mock.MagicMock(return_value=({"position_in_parent" : 0, "parent_name" : "Chassis 1"})))
+    def test_update_entity_cache(self):
+        updater = PhysicalTableMIBUpdater()
+        fc_updater = FabricCardCacheUpdater(updater)
+        update_entity_cache = getattr(fc_updater, '_update_entity_cache')
+
+        with (mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.PhysicalTableMIBUpdater.set_phy_contained_in') as mocked_phy_contained_in,
+              mock.patch('sonic_ax_impl.mibs.ietf.rfc2737.PhysicalTableMIBUpdater.set_phy_fru') as mocked_set_phy_fru):
+            update_entity_cache('N/A')
+            mocked_phy_contained_in.assert_called()
+            mocked_set_phy_fru.assert_called()

--- a/tests/test_rfc3433.py
+++ b/tests/test_rfc3433.py
@@ -37,3 +37,14 @@ class TestPhysicalSensorTableMIBUpdater(TestCase):
 
             # check re-init
             connect_all_dbs.assert_called()
+
+    @mock.patch('swsscommon.swsscommon.SonicV2Connector.get_all', mock.MagicMock(return_value=({"position_in_parent" : '0', "parent_name" : "FABRIC-CARD0"})))
+    def test_PhysicalSensorTableMIBUpdater_fabriccard_update_fan_sensor_data(self):
+        updater = PhysicalSensorTableMIBUpdater()
+        updater.fan_sensor = ['FABRIC_MODULE|FAN']
+
+        with mock.patch('sonic_ax_impl.mibs.ietf.rfc3433.get_fabric_card_sub_id') as mocked_get_fc_subid:
+            updater.update_fan_sensor_data()
+
+            # check fabric card subid function is called to get parent's sub id
+            mocked_get_fc_subid.assert_called()


### PR DESCRIPTION
With Modular Chassis, fans need not be present just in the fan drawers, but also
in fabric modules. Currently, fan and sensor information of fabric modules is
not accessible via SNMP. This patch set fixes that problem.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Essentially, make fans under fabric modules accessible in a way we currently
access fans under fan drawers.

**- How I did it**

Added a new cache updater, which keeps track of all the fans under fabric modules,
so that they can be queried via SNMP.

**- How to verify it**

SNMP walk of chassis should display the fan information, if any, present under fabric
modules.

Added a unit test and also tested these changes manually on Internal machines.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Other PR's of interest for this change: https://github.com/sonic-net/sonic-platform-daemons/pull/601, https://github.com/sonic-net/sonic-mgmt/pull/17686.

