### PR TITLE
[rfc1213] Handle error seen when interface counter is not available in COUNTERS_DB

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -411,7 +411,11 @@ class InterfacesUpdater(MIBUpdater):
             # mibs.get_index_from_str('Ethernet112') = 113 (because Ethernet N = N + 1)
             # self._get_counter retrieves the counter per oid and table.
             for lag_member in self.lag_name_if_name_map[self.oid_lag_name_map[oid]]:
-                counter_value += self._get_counter(mibs.get_index_from_str(lag_member), table_name)
+                member_counter = self._get_counter(mibs.get_index_from_str(lag_member), table_name)
+                if member_counter is not None:
+                    counter_value += member_counter
+                else:
+                    return None
             # Check if we need to add a router interface count.
             # Example:
             # self.lag_sai_map = {'PortChannel01': '2000000000006', 'PortChannel02': '2000000000005', 'PortChannel03': '2000000000004'}

--- a/tests/test_rfc1213.py
+++ b/tests/test_rfc1213.py
@@ -12,7 +12,7 @@ else:
 modules_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.join(modules_path, 'src'))
 
-from sonic_ax_impl.mibs.ietf.rfc1213 import NextHopUpdater, InterfacesUpdater
+from sonic_ax_impl.mibs.ietf.rfc1213 import NextHopUpdater, InterfacesUpdater, DbTables
 
 
 class TestNextHopUpdater(TestCase):
@@ -105,3 +105,61 @@ class TestNextHopUpdaterRedisException(TestCase):
 
                 # check re-init
                 connect_namespace_dbs.assert_called()
+
+
+    def test_InterfaceUpdater_get_counters(self):
+
+        def mock_lag_entry_table(lag_name):
+            if lag_name == "PortChannel103":
+                return "PORT_TABLE:Ethernet120"
+
+            return
+
+        def mock_get_counter(oid, table_name):
+            if oid == 121:
+                return None
+            else:
+                return updater._get_counter(oid, table_name, mask)
+
+        def mock_get_sync_d_from_all_namespace(per_namespace_func, dbs):
+            if per_namespace_func == sonic_ax_impl.mibs.init_sync_d_lag_tables:
+                return [{'PortChannel999': [], 'PortChannel103': ['Ethernet120']}, # lag_name_if_name_map
+                        {},
+                        {1999: 'PortChannel999', 1103: 'PortChannel103'}, # oid_lag_name_map
+                        {},
+                        {}]
+
+            if per_namespace_func == sonic_ax_impl.mibs.init_sync_d_interface_tables:
+                return [{},
+                        {},
+                        {},
+                        {121: 'Ethernet120'}]
+
+            if per_namespace_func == sonic_ax_impl.mibs.init_sync_d_rif_tables:
+                return [{},{}]
+
+
+            return [{},{},{}]
+
+        def mock_init_mgmt_interface_tables(db_conn):
+            return [{},{}]
+
+        def mock_dbs_get_all(dbs, db_name, hash, *args, **kwargs):
+            if hash == "PORT_TABLE:Ethernet120":
+                return {'admin_status': 'up', 'alias': 'fortyGigE0/120', 'description': 'ARISTA03T1:Ethernet1', 'index': '30', 'lanes': '101,102,103,104', 'mtu': '9100', 'oper_status': 'up', 'pfc_asym': 'off', 'speed': '40000', 'tpid': '0x8100'}
+
+            return
+
+        with mock.patch('sonic_ax_impl.mibs.Namespace.get_sync_d_from_all_namespace', mock_get_sync_d_from_all_namespace):
+            with mock.patch('sonic_ax_impl.mibs.lag_entry_table', mock_lag_entry_table):
+                with mock.patch('sonic_ax_impl.mibs.init_mgmt_interface_tables', mock_init_mgmt_interface_tables):
+                    with mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_all', mock_dbs_get_all):
+                        updater = InterfacesUpdater()
+                        updater.reinit_data()
+                        updater.update_data()
+
+        try:
+            counter = updater.get_counter((1103,), DbTables(21))
+        except TypeError:
+            self.fail("Caught Type error")
+        self.assertTrue(counter == None)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix to handle error seen:
```
ERR snmp#snmp-subagent [ax_interface] ERROR: SubtreeMIBEntry.__call__() caught an unexpected exception during _callable_.__call__()#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.11/dist-packages/ax_interface/mib.py", line 248, in __call__#012    return self._callable_.__call__(sub_id, *self._callable_args)#012           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^#012  File "/usr/local/lib/python3.11/dist-packages/sonic_ax_impl/mibs/ietf/rfc1213.py", line 414, in get_counter#012    counter_value += self._get_counter(mibs.get_index_from_str(lag_member), table_name)#012TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'
```
Above error can be seen if certain COUNTER is not supported in COUNTERS_DB. The counters present in DbTables is collected and returned in rfc1213 MIB implementation. Certain platform might not support all of these counters and can lead to the above exception.

**- How I did it**
Added logic to handle scenario where _get_counters returns None for any port-channel member interface.

**- How to verify it**
Added unit-test.
Verified on platform where "SAI_PORT_STAT_IF_OUT_QLEN" is not available.
Before fix:
```
docker exec -it snmp snmpwalk -v2c -c <comm> <IP> 1.3.6.1.2.1.2.2.1.21
WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: SyncD 'COUNTERS_DB' missing attribute ''SAI_PORT_STAT_IF_OUT_QLEN''.
ERR snmp#snmp-subagent [ax_interface] ERROR: SubtreeMIBEntry.__call__() caught an unexpected exception during _callable_.__call__()#012Traceback (most recent call last):#012  File "/usr/local/lib/python3.11/dist-packages/ax_interface/mib.py", line 248, in __call__#012    return self._callable_.__call__(sub_id, *self._callable_args)#012           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^#012  File "/usr/local/lib/python3.11/dist-packages/sonic_ax_impl/mibs/ietf/rfc1213.py", line 414, in get_counter#012    counter_value += self._get_counter(mibs.get_index_from_str(lag_member), table_name)#012TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'
```

After fix:
```
docker exec -it snmp snmpwalk -v2c -c <comm> <IP> 1.3.6.1.2.1.2.2.1.21
WARNING snmp#snmp-subagent [sonic_ax_impl] WARNING: SyncD 'COUNTERS_DB' missing attribute ''SAI_PORT_STAT_IF_OUT_QLEN''.
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

