### PR TITLE
[snmpagent][rfc1213] Optimize ipRouteNextHop default-route lookup

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -145,27 +145,27 @@ class NextHopUpdater(MIBUpdater):
         self.nexthop_map = {}
         self.route_list = []
 
-        route_entries = Namespace.dbs_keys(self.db_conn, mibs.APPL_DB, "ROUTE_TABLE:*")
-        if not route_entries:
+        route_key = "ROUTE_TABLE:0.0.0.0/0"
+        ipn = ipaddress.ip_network("0.0.0.0/0")
+        ent = Namespace.dbs_get_all(self.db_conn, mibs.APPL_DB, route_key, blocking=False)
+        if not ent:
             return
 
-        for route_entry in route_entries:
-            routestr = route_entry
-            ipnstr = routestr[len("ROUTE_TABLE:"):]
-            if ipnstr == "0.0.0.0/0":
-                ipn = ipaddress.ip_network(ipnstr)
-                ent = Namespace.dbs_get_all(self.db_conn, mibs.APPL_DB, routestr, blocking=False)
-                if ent:
-                    nexthops = ent.get("nexthop", None)
-                    if nexthops is None:
-                        mibs.logger.warning("Route has no nexthop: {} {}".format(routestr, str(ent)))
-                        continue
-                    for nh in nexthops.split(','):
-                        # TODO: if ipn contains IP range, create more sub_id here
-                        sub_id = ip2byte_tuple(ipn.network_address)
-                        self.route_list.append(sub_id)
-                        self.nexthop_map[sub_id] = ipaddress.ip_address(nh).packed
-                        break # Just need the first nexthop
+        nexthops = ent.get("nexthop", None)
+        if nexthops is None:
+            mibs.logger.warning("Route has no nexthop: {} {}".format(route_key, str(ent)))
+            return
+
+        # TODO: if ipn contains IP range, create more sub_id here
+        sub_id = ip2byte_tuple(ipn.network_address)
+        for nh in nexthops.split(','):
+            try:
+                parsed_nh = ipaddress.ip_address(nh.strip()).packed
+                self.nexthop_map[sub_id] = parsed_nh
+                self.route_list.append(sub_id)
+                break  # Just need the first nexthop
+            except ValueError:
+                mibs.logger.warning("Invalid nexthop '{}': {} {}".format(nh, route_key, str(ent)))
 
         self.route_list.sort()
 

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -159,13 +159,20 @@ class NextHopUpdater(MIBUpdater):
         # TODO: if ipn contains IP range, create more sub_id here
         sub_id = ip2byte_tuple(ipn.network_address)
         for nh in nexthops.split(','):
+            nh = nh.strip()
+            if not nh:
+                continue
             try:
-                parsed_nh = ipaddress.ip_address(nh.strip()).packed
-                self.nexthop_map[sub_id] = parsed_nh
-                self.route_list.append(sub_id)
-                break  # Just need the first nexthop
+                parsed = ipaddress.ip_address(nh)
             except ValueError:
                 mibs.logger.warning("Invalid nexthop '{}': {} {}".format(nh, route_key, str(ent)))
+                continue
+            if not isinstance(parsed, ipaddress.IPv4Address):
+                mibs.logger.warning("Route {} has non-IPv4 nexthop: {}".format(route_key, nh))
+                continue
+            self.nexthop_map[sub_id] = parsed.packed
+            self.route_list.append(sub_id)
+            break  # Just need the first nexthop
 
         self.route_list.sort()
 

--- a/tests/test_rfc1213.py
+++ b/tests/test_rfc1213.py
@@ -14,21 +14,21 @@ from sonic_ax_impl.mibs.ietf.rfc1213 import NextHopUpdater, InterfacesUpdater, D
 
 class TestNextHopUpdater(TestCase):
 
-    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_keys', mock.MagicMock(return_value=(["ROUTE_TABLE:0.0.0.0/0"])))
     @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_all', mock.MagicMock(return_value=({"nexthop": "10.0.0.1,10.0.0.3", "ifname": "Ethernet0,Ethernet4"})))
     def test_NextHopUpdater_route_has_next_hop(self):
         updater = NextHopUpdater()
 
-        with mock.patch('sonic_ax_impl.mibs.logger.warning') as mocked_warning:
+        with mock.patch('sonic_ax_impl.mibs.Namespace.dbs_keys') as mocked_dbs_keys, \
+             mock.patch('sonic_ax_impl.mibs.logger.warning') as mocked_warning:
             updater.update_data()
             
             # check warning
             mocked_warning.assert_not_called()
+            mocked_dbs_keys.assert_not_called()
 
         self.assertTrue(len(updater.route_list) == 1)
         self.assertTrue(updater.route_list[0] == (0,0,0,0))
 
-    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_keys', mock.MagicMock(return_value=(["ROUTE_TABLE:0.0.0.0/0"])))
     @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_all', mock.MagicMock(return_value=({"ifname": "Ethernet0,Ethernet4"})))
     def test_NextHopUpdater_route_no_next_hop(self):
         updater = NextHopUpdater()
@@ -44,6 +44,22 @@ class TestNextHopUpdater(TestCase):
 
         self.assertTrue(len(updater.route_list) == 0)
 
+    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_all', mock.MagicMock(return_value=({"nexthop": "bad-ip,10.0.0.1", "ifname": "Ethernet0,Ethernet4"})))
+    def test_NextHopUpdater_route_invalid_first_nexthop(self):
+        updater = NextHopUpdater()
+
+        with mock.patch('sonic_ax_impl.mibs.logger.warning') as mocked_warning:
+            updater.update_data()
+
+            expected = [
+                mock.call("Invalid nexthop 'bad-ip': ROUTE_TABLE:0.0.0.0/0 {'nexthop': 'bad-ip,10.0.0.1', 'ifname': 'Ethernet0,Ethernet4'}")
+            ]
+            mocked_warning.assert_has_calls(expected)
+
+        self.assertTrue(len(updater.route_list) == 1)
+        self.assertTrue(updater.route_list[0] == (0, 0, 0, 0))
+        self.assertTrue(updater.nexthop((0, 0, 0, 0)) == b'\n\x00\x00\x01')
+
 
 class TestNextHopUpdaterRedisException(TestCase):
     def __init__(self, name):
@@ -52,17 +68,16 @@ class TestNextHopUpdaterRedisException(TestCase):
         self.updater = NextHopUpdater()
     
     # setup mock method, throw exception when first time call it
-    def mock_dbs_keys(self, *args, **kwargs):
+    def mock_dbs_get_all(self, *args, **kwargs):
         if self.throw_exception:
             self.throw_exception = False
             raise RuntimeError
 
         self.updater.run_event.clear()
-        return None
+        return {"ifname": "Ethernet0,Ethernet4"}
 
-    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_all', mock.MagicMock(return_value=({"ifname": "Ethernet0,Ethernet4"})))
     def test_NextHopUpdater_redis_exception(self):
-        with mock.patch('sonic_ax_impl.mibs.Namespace.dbs_keys', self.mock_dbs_keys):
+        with mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_all', self.mock_dbs_get_all):
             with mock.patch('ax_interface.logger.exception') as mocked_exception:
                 self.updater.run_event.set()
                 self.updater.frequency = 1

--- a/tests/test_rfc1213.py
+++ b/tests/test_rfc1213.py
@@ -60,6 +60,38 @@ class TestNextHopUpdater(TestCase):
         self.assertTrue(updater.route_list[0] == (0, 0, 0, 0))
         self.assertTrue(updater.nexthop((0, 0, 0, 0)) == b'\n\x00\x00\x01')
 
+    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_all', mock.MagicMock(return_value=({"nexthop": "2001:db8:1111:2222:3333:4444:5555:6666,2001:db8:3333:4444:5555:6666:7777:8888", "ifname": "Ethernet0,Ethernet4"})))
+    def test_NextHopUpdater_route_ipv6_next_hop(self):
+        updater = NextHopUpdater()
+
+        with mock.patch('sonic_ax_impl.mibs.logger.warning') as mocked_warning:
+            updater.update_data()
+
+            expected = [
+                mock.call("Route ROUTE_TABLE:0.0.0.0/0 has non-IPv4 nexthop: 2001:db8:1111:2222:3333:4444:5555:6666"),
+                mock.call("Route ROUTE_TABLE:0.0.0.0/0 has non-IPv4 nexthop: 2001:db8:3333:4444:5555:6666:7777:8888")
+            ]
+            mocked_warning.assert_has_calls(expected)
+
+        self.assertTrue(len(updater.route_list) == 0)
+        self.assertTrue(len(updater.nexthop_map) == 0)
+
+    @mock.patch('sonic_ax_impl.mibs.Namespace.dbs_get_all', mock.MagicMock(return_value=({"nexthop": "2001:db8:1111:2222:3333:4444:5555:6666,127.1.1.1", "ifname": "Ethernet0,Ethernet4"})))
+    def test_NextHopUpdater_route_ipv4_ipv6_next_hop(self):
+        updater = NextHopUpdater()
+
+        with mock.patch('sonic_ax_impl.mibs.logger.warning') as mocked_warning:
+            updater.update_data()
+
+            expected = [
+                mock.call("Route ROUTE_TABLE:0.0.0.0/0 has non-IPv4 nexthop: 2001:db8:1111:2222:3333:4444:5555:6666")
+            ]
+            mocked_warning.assert_has_calls(expected)
+
+        self.assertTrue(len(updater.route_list) == 1)
+        self.assertTrue(len(updater.nexthop_map) == 1)
+        self.assertTrue(updater.nexthop((0, 0, 0, 0)) == b'\x7f\x01\x01\x01')
+
 
 class TestNextHopUpdaterRedisException(TestCase):
     def __init__(self, name):


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**What I did**

Optimized `ipRouteNextHop` handling in `rfc1213.py` to avoid scanning all route keys in `APPL_DB`, while preserving RFC1213 default-route behavior.
- Replaced `ROUTE_TABLE:*` scan + filter with direct lookup of `ROUTE_TABLE:0.0.0.0/0`.
- Kept behavior of selecting the first valid IPv4 nexthop.
- Added robust parsing for nexthop tokens (`strip()` + invalid-token handling).
- Skip non-IPv4 nexthops (IPv6 tokens are ignored with warning), aligned with RFC1213 IPv4 semantics.
- Ensured `route_list` is updated only after successful IPv4 nexthop parse.
- Updated unit tests in `tests/test_rfc1213.py` for direct lookup path, invalid-token fallback, and IPv6/IPv4 nexthop cases.

**How I did it**

Modified `NextHopUpdater.update_data()` to:
1. Query only `ROUTE_TABLE:0.0.0.0/0` from `APPL_DB`.
2. Read `nexthop` field from the returned route entry.
3. Parse nexthops left-to-right and pick the first valid IPv4 token.
4. Log warning for invalid/non-IPv4 tokens and continue scanning remaining tokens.
5. Populate SNMP route cache only when a valid IPv4 nexthop is found.


**How to verify it**

- Unit tests: `tests/test_rfc1213.py`
- DUT functional validation on a Broadcom-based SONiC switch with large BGP route scale (~250k routes):
  - Verified optimized code path (`ROUTE_TABLE:0.0.0.0/0` direct lookup + IPv4-only nexthop filter)
  - No default route: `snmpwalk 1.3.6.1.2.1.4.21.1.7` returns `No Such Instance` in <200ms (stable across repeated polls)
  - With temporary static default route (`0.0.0.0/0` via valid IPv4 nexthop): `snmpwalk/get` returns expected IPv4 nexthop in <200ms
  - After route removal: behavior restored to `No Such Instance`

**- Which release branch to backport (provide reason below if selected)**

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: N/A (optimization; no backport requested)

**- Tested branch**

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605
- [ ] N/A

**- Test result**

- master:
  - Unit tests in `tests/test_rfc1213.py` passed
  - DUT SNMP validation passed on a large-scale route table (~250k BGP routes), covering:
    - no default route (`No Such Instance`, fast response)
    - temporary default route (expected IPv4 nexthop returned, fast response)
  - Repeated polling showed stable behavior with no timeout/hang

**Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Optimize SNMP `ipRouteNextHop` default-route lookup by replacing full route-table scan with direct `ROUTE_TABLE:0.0.0.0/0` query and improving IPv4 nexthop parsing robustness.

