### PR TITLE
Adapt SNMP for state_db mgmt_port_table entries

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -201,6 +201,24 @@ class InterfaceMIBUpdater(MIBUpdater):
 
         return result
     
+    def _get_if_entry_state_db(self, oid):
+        """
+        :param oid: The 1-based sub-identifier query.
+        :return: the DB entry for the respective sub_id.
+        """
+        if not oid:
+            return
+
+        if_table = ""
+        db = mibs.STATE_DB
+        if oid in self.mgmt_oid_name_map:
+            mgmt_if_name = self.mgmt_oid_name_map[oid]
+            if_table = mibs.mgmt_if_entry_table_state_db(mgmt_if_name)
+        else:
+            return None
+
+        return Namespace.dbs_get_all(self.db_conn, db, if_table, blocking=False)
+
     def interface_alias(self, sub_id):
         """
         ifAlias specific - this is not the "Alias map".
@@ -310,7 +328,11 @@ class InterfaceMIBUpdater(MIBUpdater):
                     speed += int(entry.get("speed", 0))
             return speed
 
-        entry = self._get_if_entry(oid)
+        if oid in self.mgmt_oid_name_map:
+            entry = self._get_if_entry_state_db(oid)
+        else:
+            entry = self._get_if_entry(oid)
+
         if not entry:
             return
 

--- a/tests/mock_tables/asic0/state_db.json
+++ b/tests/mock_tables/asic0/state_db.json
@@ -42,5 +42,17 @@
   },
   "BUFFER_MAX_PARAM_TABLE|Ethernet24": {
     "max_queues": "16"
+  },
+  "MGMT_PORT_TABLE:Ethernet0": {
+    "description": "snowflake",
+    "alias": "etp1",
+    "role": "Ext",
+    "speed": 100000
+  },
+  "MGMT_PORT_TABLE:Ethernet4": {
+    "description": "snowflake",
+    "alias": "etp2",
+    "role": "Ext",
+    "speed": 100000
   }
 }

--- a/tests/mock_tables/asic1/state_db.json
+++ b/tests/mock_tables/asic1/state_db.json
@@ -39,5 +39,16 @@
   },
   "BUFFER_MAX_PARAM_TABLE|Ethernet32": {
     "max_queues": "16"
+  },
+  "MGMT_PORT_TABLE:Ethernet8": {
+    "description": "snowflake",
+    "alias": "etp5",
+    "role": "Ext",
+    "speed": 100000
+  },
+  "MGMT_PORT_TABLE:Ethernet12": {
+    "speed": 1000,
+    "role": "Ext",
+    "alias": "etp6"
   }
 }

--- a/tests/mock_tables/global_db/state_db.json
+++ b/tests/mock_tables/global_db/state_db.json
@@ -65,10 +65,22 @@
     "tx4power": -5.4
   },
   "MGMT_PORT_TABLE|eth0": {
-    "oper_status": "down"
+    "description": "snowflake",
+    "oper_status": "down",
+    "speed": 1000
   },
   "MGMT_PORT_TABLE|eth1": {
-    "oper_status": "up"
+    "description": "snowflake",
+    "admin_status": "up",
+    "oper_status": "up",
+    "alias": "mgmt1",
+    "speed": 1000
+  },
+  "MGMT_PORT_TABLE|eth2": {
+    "description": "NotExistInStateDB",
+    "admin_status": "up",
+    "alias": "mgmt2",
+    "speed": 1000
   },
   "PHYSICAL_ENTITY_INFO|PSU 1": {
     "position_in_parent": 1,

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -89,10 +89,15 @@
     "tx4power": "N/A"
   },
   "MGMT_PORT_TABLE|eth0": {
-    "oper_status": "down"
+    "description": "snowflake",
+    "speed": 1000
   },
   "MGMT_PORT_TABLE|eth1": {
-    "oper_status": "up"
+    "description": "snowflake",
+    "oper_status": "up",
+    "admin_status": "up",
+    "alias": "mgmt1",
+    "speed": 2000
   },
   "PHYSICAL_ENTITY_INFO|PSU 1": {
     "position_in_parent": 1,

--- a/tests/test_hc_interfaces.py
+++ b/tests/test_hc_interfaces.py
@@ -275,3 +275,77 @@ class TestGetNextPDU(TestCase):
         self.assertEqual(value0.type_, ValueType.COUNTER_64)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(12, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 6, 5))))
         self.assertEqual(value0.data, 654321)
+
+    def test_mgmt_iface_ifMIB(self):
+        """
+            Test that mgmt port is present in the ifMIB OID path of the MIB
+        """
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 10000))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        print(response)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.OCTET_STRING)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 10001))))
+        self.assertEqual(str(value0.data), "snowflake")
+
+    def test_mgmt_iface_speed_eth2(self):
+        """
+        Test that mgmt port speed is 1000
+        """
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 15, 10001))
+        get_pdu = GetPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        print(response)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.GAUGE_32)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 15, 10001))))
+        self.assertEqual(value0.data, 2000)
+
+    def test_mgmt_iface_speed_getnext_eth0(self):
+        """
+        Test that mgmt port speed is 1000
+        """
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 15, 10000))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        print(response)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.GAUGE_32)
+        self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 15, 10001))))
+        self.assertEqual(value0.data, 2000)
+
+    def test_mgmt_iface_speed_getnext_eth1(self):
+        """
+        Test that mgmt port speed is 1000
+        """
+        oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 15, 10001))
+        get_pdu = GetNextPDU(
+            header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
+            oids=[oid]
+        )
+
+        encoded = get_pdu.encode()
+        response = get_pdu.make_response(self.lut)
+        print(response)
+
+        value0 = response.values[0]
+        self.assertEqual(value0.type_, ValueType.END_OF_MIB_VIEW)


### PR DESCRIPTION
### Why I did it

`ifHighSpeed` (`ifMIB.ifXTable.ifHighSpeed`, OID `.1.3.6.1.2.1.31.1.1.1.15`) returns `0` (or the `40000` default) for management interfaces in setups where the operational speed of the mgmt port is published in `STATE_DB` rather than `CONFIG_DB`.

Today `InterfaceMIBUpdater._get_if_entry()` looks up management ports under `MGMT_PORT|<name>` in **CONFIG_DB** only. On platforms where the mgmt driver writes the live link speed (and other operational fields) into `STATE_DB`'s `MGMT_PORT_TABLE|<name>`, the CONFIG_DB row may not carry a `speed` field at all, so `ifHighSpeed` falls back to the hard-coded default and SNMP polling shows the wrong management-port speed.

`rfc1213.py` already has the same two-tier lookup helper (`mgmt_if_entry_table_state_db`) for `ifSpeed`. This PR brings `rfc2863.py` (`ifXTable`) in line with that behavior so `ifHighSpeed` reflects reality on those platforms.

### What I did

- Added a new `InterfaceMIBUpdater._get_if_entry_state_db()` helper in `src/sonic_ax_impl/mibs/ietf/rfc2863.py`. For an OID that maps to a management port, it reads the entry from `STATE_DB` via the existing `mibs.mgmt_if_entry_table_state_db(name)` table builder (`MGMT_PORT_TABLE|<name>`), using `Namespace.dbs_get_all(..., blocking=False)` so a missing key returns `None` instead of stalling the SNMP request.
- Updated `get_high_speed()` so that when the queried OID is a management port, it pulls the entry from `STATE_DB` (via the new helper); for all other interface types (physical ports, LAGs, VLANs) the existing `CONFIG_DB`/`APPL_DB`-based `_get_if_entry()` path is unchanged.
- Behavior is purely additive: existing flows for non-mgmt ports are untouched, and `int(entry.get("speed", 40000))` still applies if `STATE_DB` has no `speed` field — so the default fallback is preserved.

#### Files changed

- `src/sonic_ax_impl/mibs/ietf/rfc2863.py` — new `_get_if_entry_state_db()` and updated `get_high_speed()`.
- `tests/test_hc_interfaces.py` — four new unit tests covering:
  - `GETNEXT` walks over `ifXTable` end up at the mgmt-port row (proves mgmt port is reachable in the MIB).
  - `GET ifHighSpeed` on a mgmt port returns the value sourced from `STATE_DB` (e.g. `2000`).
  - `GETNEXT ifHighSpeed` on the prior OID lands on the mgmt port with the correct speed.
  - `GETNEXT` past the last mgmt port returns `END_OF_MIB_VIEW`.
- `tests/mock_tables/state_db.json`, `tests/mock_tables/global_db/state_db.json`, `tests/mock_tables/asic0/state_db.json`, `tests/mock_tables/asic1/state_db.json` — extended `MGMT_PORT_TABLE` mocks with `description`, `alias`, `admin_status`, `speed`, etc., including a `NotExistInStateDB` case to exercise the missing-row path. Multi-asic mocks (`asic0` / `asic1`) use the `MGMT_PORT_TABLE:<name>` colon-separated form to match how multi-asic STATE_DB serializes keys.
